### PR TITLE
drivers: wifi: Restored TLS functionality to 9116 driver

### DIFF
--- a/drivers/wifi/rs9116w/Kconfig.rs9116w
+++ b/drivers/wifi/rs9116w/Kconfig.rs9116w
@@ -47,7 +47,7 @@ if RS9116W_TLS_OFFLOAD
 
 config RS9116W_TLS_PEM_BUF_SZ
 	int "Buffer size to allocate for PEM conversion"
-	default 1500
+	default 2000
 
 endif # RS9116W_TLS_OFFLOAD
 

--- a/drivers/wifi/rs9116w/rs9116w_socket_offload.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket_offload.c
@@ -129,21 +129,19 @@ static int rs9116w_socket(int family, int type, int proto)
 			rsi_proto = PROTOCOL_TLS_1_2;
 			break;
 		}
-	} else if (proto >= IPPROTO_DTLS_1_0 && proto <= IPPROTO_DTLS_1_2) {
-		/* Don't think the 9116 supports DTLS */
-		errno = EPROTONOSUPPORT;
-		return -1;
+	} else {
+		switch (proto) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP:
+			rsi_proto = 0;
+			break;
+		default:
+			LOG_ERR("unrecognized proto: %d", proto);
+			errno = EPROTONOSUPPORT;
+			return -1;
+		}
 	}
-	switch (proto) {
-	case IPPROTO_TCP:
-	case IPPROTO_UDP:
-		rsi_proto = 0;
-		break;
-	default:
-		LOG_ERR("unrecognized proto: %d", proto);
-		errno = EPROTONOSUPPORT;
-		return -1;
-	}
+
 
 	sd = rsi_socket(family, type, rsi_proto);
 	if (sd >= 0) {


### PR DESCRIPTION
Removed extraneous references to DTLS from RS9116W and fixed protocol conversion logic.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>