### PR TITLE
drivers: wifi: Fix errornos in 9116 Driver

### DIFF
--- a/drivers/wifi/rs9116w/rs9116w_socket_offload.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket_offload.c
@@ -729,6 +729,10 @@ static ssize_t rs9116w_recvfrom(void *obj, void *buf, size_t len, int flags,
 
 	len = MIN(len, MAX_PAYLOAD_SIZE);
 
+	if (len == 0) {
+		return -EINVAL;
+	}
+
 	/* 1k to account for TLS overhead */
 	size_t per_rcv = MAX_PAYLOAD_SIZE;
 
@@ -859,6 +863,10 @@ static ssize_t rs9116w_sendto(void *obj, const void *buf, size_t len, int flags,
 		retval = rsi_sendto(sd, (int8_t *)buf, len, flags, rsi_addr,
 				    rsi_addrlen);
 	} else {
+		if (rsi_socket_pool[sd].sock_state != RSI_SOCKET_STATE_CONNECTED) {
+			errno = ENOTCONN;
+			return -1;
+		}
 		retval = rsi_send(sd, (int8_t *)buf, len, flags);
 	}
 


### PR DESCRIPTION
Fixed errno responses for sending without connection and doing receives of size zero.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>