### PR TITLE
driver: wifi: Fix 9116 PM dependence on bluetooth

### DIFF
--- a/drivers/wifi/rs9116w/rs9116w_mgmt.c
+++ b/drivers/wifi/rs9116w/rs9116w_mgmt.c
@@ -552,8 +552,8 @@ static const struct net_wifi_mgmt_offload rs9116w_api = {
 #if CONFIG_WISECONNECT_BT
 extern int bt_le_adv_stop(void);
 extern void bt_le_adv_resume(void);
-#endif
 #include <rsi_bt_common_apis.h>
+#endif
 static int rs9116w_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {


### PR DESCRIPTION
Fixed issue where a bluetooth header would be referenced in RS9116 power management with bluetooth disabled

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>