### PR TITLE
drivers: bluetooth: Add semaphore to BLE event queues

### DIFF
--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.h
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.h
@@ -8,9 +8,9 @@
 #ifndef RS9116W_BLE_CONN_H_
 #define RS9116W_BLE_CONN_H_
 
-#include <zephyr.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 #include <rsi_ble_common_config.h>
 #ifndef LOG_MODULE_NAME
 #define LOG_MODULE_NAME rsi_bt_conn


### PR DESCRIPTION
Added semaphores for event queues in the RS9116W bluetooth driver.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>