### PR TITLE
drivers: Fix RS9116 driver compile on HEAD

### DIFF
--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/drivers/bluetooth/rs9116w.h>
 
-#include <bluetooth/hci_err.h>
+#include <zephyr/bluetooth/hci_err.h>
 /* Peripheral timeout to initialize Connection Parameter Update procedure */
 #define CONN_UPDATE_TIMEOUT K_MSEC(CONFIG_BT_CONN_PARAM_UPDATE_TIMEOUT)
 
@@ -683,7 +683,7 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 
 /* BLE SMP */
 #if defined(CONFIG_BT_SMP)
-uint8_t bt_conn_enc_key_size(struct bt_conn *conn)
+uint8_t bt_conn_enc_key_size(const struct bt_conn *conn)
 {
 	return ENC_KEY_DEFAULT_SIZE;
 }
@@ -733,7 +733,7 @@ int bt_conn_set_security(struct bt_conn *conn,
 	return err;
 }
 
-bt_security_t bt_conn_get_security(struct bt_conn *conn)
+bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 {
 	return conn->sec_level;
 }
@@ -749,7 +749,7 @@ void security_changed(struct bt_conn *conn, uint8_t status)
 	}
 }
 #else
-bt_security_t bt_conn_get_security(struct bt_conn *conn)
+bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 {
 	return BT_SECURITY_L1;
 }

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.h
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.h
@@ -8,9 +8,9 @@
 #ifndef RS9116W_BLE_CONN_H_
 #define RS9116W_BLE_CONN_H_
 
-#include <zephyr.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 #include <rsi_ble_common_config.h>
 #ifndef LOG_MODULE_NAME
 #define LOG_MODULE_NAME rsi_bt_conn

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.c
@@ -12,9 +12,9 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <random/rand32.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/random/rand32.h>
 
 #if !IS_ENABLED(CONFIG_WIFI_RS9116W)
 /* Buffer for WiSeConnect */

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.h
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.h
@@ -9,17 +9,17 @@
 #ifndef RS9116W_BLE_CORE_H_
 #define RS9116W_BLE_CORE_H_
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/uuid.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/uuid.h>
 #include <rsi_common_apis.h>
 #include <rsi_bt_common.h>
 #include <rsi_bt_common_apis.h>
 #include <rsi_ble_apis.h>
 #include <rsi_driver.h>
 #include "rsi_ble_config.h"
-#include <zephyr.h>
-#include <logging/log.h>
-#include <sys/byteorder.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 
 extern uint8_t rsi_bt_random_addr[6];
 

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gap.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gap.c
@@ -7,13 +7,14 @@
  */
 #include "rs9116w_ble_gap.h"
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include <rsi_ble.h>
 #include <rsi_ble_apis.h>
 #include <rsi_bt_apis.h>
 #include <rsi_bt_common.h>
 #include <rsi_bt_common_apis.h>
 #include <rsi_common_apis.h>
+#include <zephyr/types.h>
 #include <sys/types.h>
 
 struct bt_le_ext_adv dev_adv;

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gap.h
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gap.h
@@ -9,8 +9,8 @@
 #ifndef RS9116W_BLE_GAP_H_
 #define RS9116W_BLE_GAP_H_
 
-#include <bluetooth/bluetooth.h>
-#include <zephyr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/kernel.h>
 #define LOG_MODULE_NAME rsi_bt_gap
 #include "rs9116w_ble_conn.h"
 

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gatt.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gatt.c
@@ -6,14 +6,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/gatt.h>
 #include <rsi_ble.h>
 #include <rsi_ble_apis.h>
 #include <rsi_ble_common_config.h>
 #include <rsi_bt_apis.h>
 #include <rsi_bt_common.h>
 #include <rsi_common_apis.h>
-#include <zephyr.h>
+#include <zephyr/kernel.h>
 #define LOG_MODULE_NAME rsi_bt_gatt
 #include "rs9116w_ble_conn.h"
 #if defined(BT_L2CAP_RX_MTU) && defined(BT_L2CAP_TX_MTU)

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_keys.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_keys.c
@@ -7,18 +7,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/atomic.h>
-#include <sys/util.h>
-#include <sys/byteorder.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci.h>
 #define LOG_MODULE_NAME rsi_bt_keys
 #include "rs9116w_ble_core.h"
 

--- a/drivers/wifi/rs9116w/rs9116w.h
+++ b/drivers/wifi/rs9116w/rs9116w.h
@@ -7,10 +7,10 @@
 #ifndef ZEPHYR_DRIVERS_WIFI_RS9116W_RS9116W_H_
 #define ZEPHYR_DRIVERS_WIFI_RS9116W_RS9116W_H_
 
-#include <device.h>
-#include <drivers/spi.h>
-#include <net/net_if.h>
-#include <net/wifi_mgmt.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/wifi_mgmt.h>
 
 /* Undef macros before redefining to eliminate warnings */
 #undef AF_INET
@@ -19,6 +19,7 @@
 #undef PF_INET
 #undef PF_INET6
 #undef TCP_NODELAY
+#undef IP_TOS
 #include <rsi_socket.h>
 #include <rsi_wlan_apis.h>
 

--- a/drivers/wifi/rs9116w/rs9116w_mgmt.c
+++ b/drivers/wifi/rs9116w/rs9116w_mgmt.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #define LOG_MODULE_NAME wifi_rs9116w_mgmt
 #define LOG_LEVEL	CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define DT_DRV_COMPAT silabs_rs9116w
@@ -22,16 +22,16 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 
-#include <debug/stack.h>
-#include <device.h>
-#include <kernel.h>
-#include <net/net_context.h>
-#include <net/net_if.h>
-#include <net/net_l2.h>
-#include <net/net_offload.h>
-#include <net/net_pkt.h>
-#include <net/wifi_mgmt.h>
-#include <zephyr.h>
+#include <zephyr/debug/stack.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_offload.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/kernel.h>
 
 #undef s6_addr
 #undef s6_addr32
@@ -541,7 +541,7 @@ static int rs9116w_init(const struct device *dev)
 
 /* TODO: make these asynchronous */
 static const struct net_wifi_mgmt_offload rs9116w_api = {
-	.iface_api.init = rs9116w_iface_init, /* called after device init fcn */
+	.wifi_iface.init = rs9116w_iface_init, /* called after device init fcn */
 	.scan = rs9116w_mgmt_scan,
 	.connect = rs9116w_mgmt_connect,
 	.disconnect = rs9116w_mgmt_disconnect,

--- a/drivers/wifi/rs9116w/rs9116w_socket.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket.c
@@ -6,16 +6,16 @@
 
 #define LOG_MODULE_NAME wifi_rs9116w_offload
 #define LOG_LEVEL	CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "rs9116w.h"
 #include "rsi_wlan.h"
 
-#include <net/net_context.h>
-#include <net/net_ip.h>
-#include <net/net_offload.h>
-#include <net/net_pkt.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_offload.h>
+#include <zephyr/net/net_pkt.h>
 #include <rsi_wlan_apis.h>
 #undef s6_addr
 #undef s6_addr32

--- a/drivers/wifi/rs9116w/rs9116w_socket_offload.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket_offload.c
@@ -6,7 +6,7 @@
 
 #define LOG_MODULE_NAME wifi_rs9116w_socket_offload
 #define LOG_LEVEL	CONFIG_WIFI_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/kernel.h>
@@ -496,7 +496,7 @@ static int rs9116w_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 
 #if IS_ENABLED(CONFIG_NET_SOCKETS_SOCKOPT_TLS) &&                              \
 	IS_ENABLED(CONFIG_RS9116W_TLS_OFFLOAD)
-#include <sys/base64.h>
+#include <zephyr/sys/base64.h>
 uint8_t pem[CONFIG_RS9116W_TLS_PEM_BUF_SZ];
 
 static int map_credentials(int sd, const void *optval, socklen_t optlen)

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
       revision: e8920192b66db4f909eb9cd3f155d5245c1ae825
       path: modules/lib/uoscore-uedhoc
     - name: wiseconnect
-      revision: b5826aa21a3e087d7fbb5cad1e47ebb86f6409ee
+      revision: d4ea12d64752f2c6367563f71cde7bbee21d7411
       path: modules/hal/silabs_wiseconnect
       url: https://ryanhagen-tmo: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@github.com/tmobile/DevEdge-IoTDevKit-SiLabs-WiseConnect.git
       groups:


### PR DESCRIPTION
Fixed RS9116 drivers not compiling in up-to-date zephyr.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>