### PR TITLE
dts: bindings: Fix murata 1SC bindings

### DIFF
--- a/drivers/modem/murata-1sc.c
+++ b/drivers/modem/murata-1sc.c
@@ -1025,10 +1025,6 @@ static int set_psm_timer(struct set_cpsms_params *Parms)
 	char t3324[PSM_TIME_LEN];
 	int ret;
 
-	if (&mctx.iface == NULL) {
-		return -1;
-	}
-
 	strcpy(t3312, (const char *)byte_to_binary_str(Parms->t3312_mask));
 	strcpy(t3314, (const char *)byte_to_binary_str(Parms->t3314_mask));
 	strcpy(t3412, (const char *)byte_to_binary_str(Parms->t3412_mask));

--- a/dts/bindings/modem/murata,1sc.yaml
+++ b/dts/bindings/modem/murata,1sc.yaml
@@ -8,9 +8,6 @@ compatible: "murata,1sc"
 include: uart-device.yaml
 
 properties:
-    label:
-      required: true
-
     mdm-wake-host-gpios:
       type: phandle-array
       required: true


### PR DESCRIPTION
Removed the deprecated label binding as a requirement in the Murata 1SC bindings.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>