### PR TITLE
modules: Fix WiSeConnect URL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -263,9 +263,9 @@ manifest:
       revision: e8920192b66db4f909eb9cd3f155d5245c1ae825
       path: modules/lib/uoscore-uedhoc
     - name: wiseconnect
-      revision: b5826aa21a3e087d7fbb5cad1e47ebb86f6409ee
+      revision: 17f1596d54ab16cb86225f11f1c6204f33ffcd05
       path: modules/hal/silabs_wiseconnect
-      url: git@github.com:tmobile/DevEdge-IoTDevKit-SiLabs-WiseConnect.git
+      url: https://github.com/tmobile/DevEdge-IoTDevKit-SiLabs-WiseConnect.git
       groups:
         - hal
     - name: zcbor


### PR DESCRIPTION
Changed WiSeConnect URL to HTTPS to fix pipeline failure.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>