### PR TITLE
drivers: Fix RS9116 driver compile on HEAD

### DIFF
--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_conn.c
@@ -683,7 +683,7 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 
 /* BLE SMP */
 #if defined(CONFIG_BT_SMP)
-uint8_t bt_conn_enc_key_size(struct bt_conn *conn)
+uint8_t bt_conn_enc_key_size(const struct bt_conn *conn)
 {
 	return ENC_KEY_DEFAULT_SIZE;
 }
@@ -733,7 +733,7 @@ int bt_conn_set_security(struct bt_conn *conn,
 	return err;
 }
 
-bt_security_t bt_conn_get_security(struct bt_conn *conn)
+bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 {
 	return conn->sec_level;
 }
@@ -749,7 +749,7 @@ void security_changed(struct bt_conn *conn, uint8_t status)
 	}
 }
 #else
-bt_security_t bt_conn_get_security(struct bt_conn *conn)
+bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 {
 	return BT_SECURITY_L1;
 }

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gap.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_gap.c
@@ -14,6 +14,7 @@
 #include <rsi_bt_common.h>
 #include <rsi_bt_common_apis.h>
 #include <rsi_common_apis.h>
+#include <zephyr/types.h>
 #include <sys/types.h>
 
 struct bt_le_ext_adv dev_adv;

--- a/drivers/wifi/rs9116w/rs9116w.h
+++ b/drivers/wifi/rs9116w/rs9116w.h
@@ -19,6 +19,7 @@
 #undef PF_INET
 #undef PF_INET6
 #undef TCP_NODELAY
+#undef IP_TOS
 #include <rsi_socket.h>
 #include <rsi_wlan_apis.h>
 

--- a/drivers/wifi/rs9116w/rs9116w_mgmt.c
+++ b/drivers/wifi/rs9116w/rs9116w_mgmt.c
@@ -541,7 +541,7 @@ static int rs9116w_init(const struct device *dev)
 
 /* TODO: make these asynchronous */
 static const struct net_wifi_mgmt_offload rs9116w_api = {
-	.iface_api.init = rs9116w_iface_init, /* called after device init fcn */
+	.wifi_iface.init = rs9116w_iface_init, /* called after device init fcn */
 	.scan = rs9116w_mgmt_scan,
 	.connect = rs9116w_mgmt_connect,
 	.disconnect = rs9116w_mgmt_disconnect,


### PR DESCRIPTION
Fixed RS9116 drivers not compiling in up-to-date zephyr.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>