### PR TITLE
drivers: wifi: Fix ping in 9116 driver

### DIFF
--- a/drivers/wifi/rs9116w/Kconfig.rs9116w
+++ b/drivers/wifi/rs9116w/Kconfig.rs9116w
@@ -77,4 +77,9 @@ endif # RS9116_DNS_SERVER_IP_ADDRESSES
 
 endif # NET_SOCKETS_OFFLOAD
 
+config RS9116W_ICMP
+	bool
+	select WISECONNECT_ICMP
+	default y if PING
+
 endif # WIFI_RS9116W


### PR DESCRIPTION
Updated kconfig to properly set wiseconnect ICMP to true if ping is requested.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>