### PR TITLE
drivers: wifi: Fix RS9116 ignoring socket limit

### DIFF
--- a/drivers/wifi/rs9116w/rs9116w_socket_offload.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket_offload.c
@@ -150,6 +150,16 @@ static int rs9116w_socket(int family, int type, int proto)
 	}
 
 	sd = rsi_socket(family, type, rsi_proto);
+
+	/* Unfortunately the WiSeConnect config doesn't work quite right, as such
+	 * a check had to be added here.
+	 */
+	if (sd >= CONFIG_WISECONNECT_SOCKETS_COUNT) {
+		(void)rsi_shutdown(sd, 0);
+		errno = ENFILE;
+		return -1;
+	}
+
 	if (sd >= 0) {
 		if (IS_ENABLED(CONFIG_NET_SOCKETS_SOCKOPT_TLS) &&
 		    rsi_proto == 1) {
@@ -1007,7 +1017,7 @@ int rs9116w_socket_create(int family, int type, int proto)
 		atomic_clear_bit(closed_socks_map, sock);
 	}
 
-	LOG_DBG("SOCK CREATE %d", sock);
+	LOG_DBG("rs9116w_socket returned %d", sock);
 	if (sock < 0) {
 		z_free_fd(fd);
 		return -1;


### PR DESCRIPTION
Added fix so that the driver will adhere to the defined socket limits.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>