### PR TITLE
CODEOWNERS: Remove Jay Rickard from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,6 @@
 # Order is important; for each modified file, the last matching
 # pattern takes the most precedence.
 
-/*                                         @johnlange2 @ryanhagen-tmo @eniolaodufuwa-tmo @jtbaumann @DRuffer-tmo @jayrickard-tmo @joebairdtmo @atrowbr2-tmo @kimmansfield @wtucker6
+/*                                         @johnlange2 @ryanhagen-tmo @eniolaodufuwa-tmo @jtbaumann @DRuffer-tmo @joebairdtmo @atrowbr2-tmo @kimmansfield @wtucker6
 /.github/workflows/                        @ryanhagen-tmo @eniolaodufuwa-tmo
 /west.yml                                  @ryanhagen-tmo @eniolaodufuwa-tmo


### PR DESCRIPTION
Removed Jay from the CODEOWNERS file.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>