### PR TITLE
drivers: wifi: Fix errno on udp recv unbound

### DIFF
--- a/drivers/wifi/rs9116w/rs9116w_socket_offload.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket_offload.c
@@ -766,6 +766,10 @@ static ssize_t rs9116w_recvfrom(void *obj, void *buf, size_t len, int flags,
 	 * Therefore, this is the simplest solution...
 	 */
 	if (flags & ZSOCK_MSG_DONTWAIT) {
+		if (rsi_socket_pool[sd].sock_state < RSI_SOCKET_STATE_BIND) {
+			errno = EAGAIN;
+			return -1;
+		}
 		struct rsi_timeval ptv;
 		rsi_fd_set rfds;
 


### PR DESCRIPTION
Fixed the returned errno value for unboud udp sockets for RS9116W driver

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>