### PR TITLE
drivers: wifi: Fixed RS9116 response on zero sized recieves

### DIFF
--- a/drivers/wifi/rs9116w/rs9116w_socket_offload.c
+++ b/drivers/wifi/rs9116w/rs9116w_socket_offload.c
@@ -734,7 +734,8 @@ static ssize_t rs9116w_recvfrom(void *obj, void *buf, size_t len, int flags,
 	len = MIN(len, MAX_PAYLOAD_SIZE);
 
 	if (len == 0) {
-		return -EINVAL;
+		errno = EINVAL;
+		return -1;
 	}
 
 	/* 1k to account for TLS overhead */


### PR DESCRIPTION
Fixed errno value/return value for a zero-sized recieve.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>