### PR TITLE
drivers: sensor: Remove force suspend from CXD5605

### DIFF
--- a/drivers/sensor/cxd5605/cxd5605.c
+++ b/drivers/sensor/cxd5605/cxd5605.c
@@ -704,7 +704,6 @@ static int cxd5605_driver_pm_action(const struct device *dev,
 			printk("ERROR: I2C interface not working (CXD5605 driver)\n");
 		}
 
-	case PM_DEVICE_ACTION_FORCE_SUSPEND:
 	case PM_DEVICE_ACTION_SUSPEND:
 		cxd5605_sleep(dev, 0);
 		break;


### PR DESCRIPTION
Remove the force suspend power management option from the pm actions.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>