### PR TITLE
drivers: bluetooth: Fix bt_keys log issues

### DIFF
--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.h
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.h
@@ -93,23 +93,17 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 #define BT_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define BT_INFO(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
 
-
-const char *bt_hex_real(const void *buf, size_t len);
-
-const char *bt_addr_str_real(const bt_addr_t *addr);
-
-const char *bt_addr_le_str_real(const bt_addr_le_t *addr);
-
-const char *bt_uuid_str_real(const struct bt_uuid *uuid);
-
 void rsi_connection_cleanup_task(void);
 
-#define bt_hex(buf, len) bt_hex_real(buf, len)
-#define bt_addr_str(addr) bt_addr_str_real(addr)
-#define bt_addr_le_str(addr) bt_addr_le_str_real(addr)
-#define bt_uuid_str(uuid) bt_uuid_str_real(uuid)
-
-
 void rsi_bt_raise_evt(void);
+
+/* NOTE: These helper functions encode into a shared buffer. Therefore, the
+ * output must be copied/preserved before making subsequent helper function
+ * calls.
+ */
+const char *bt_hex(const void *buf, size_t len);
+const char *bt_addr_str(const bt_addr_t *addr);
+const char *bt_addr_le_str(const bt_addr_le_t *addr);
+const char *bt_uuid_str(const struct bt_uuid *uuid);
 
 #endif


### PR DESCRIPTION
Fixed issues where older versions of "bt_addr_le_str" and "bt_hex" are no longer available.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>