### PR TITLE
samples: add tmo_dev_edge config in fs shell sample

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,4 @@
 /.github/workflows/                        @ryanhagen-tmo @eniolaodufuwa-tmo
 /west.yml                                  @ryanhagen-tmo @eniolaodufuwa-tmo
 include/zephyr/drivers/sensor/tsl2540.h    @jtbaumann
+samples/subsys/shell/fs/boards/tmo_dev_edge.conf @jtbaumann

--- a/samples/subsys/shell/fs/boards/tmo_dev_edge.conf
+++ b/samples/subsys/shell/fs/boards/tmo_dev_edge.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 T-Mobile USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+CONFIG_SPI_GECKO=y


### PR DESCRIPTION
Add configuration for the T-Mobile DevEdge in the fs shell sample.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>