### PR TITLE
boards: arm: Add ODR to LPS22HH on DevEdge

### DIFF
--- a/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
+++ b/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
@@ -273,6 +273,7 @@
 		compatible = "st,lps22hh";
 		reg = <0x5c 0x4>;
 		status = "okay";
+		odr = <1>;
 		drdy-gpios =  <&gpiof 15 GPIO_ACTIVE_HIGH>;
 	};
 


### PR DESCRIPTION
Added value for ODR for LPS22HH on devedge to allow sensor shell to function properly.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>