### PR TITLE
drivers: bluetooth: Enable services on 9116 driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,5 @@
 /west.yml                                  @ryanhagen-tmo @eniolaodufuwa-tmo
 include/zephyr/drivers/sensor/tsl2540.h    @jtbaumann
 samples/subsys/shell/fs/boards/tmo_dev_edge.conf @jtbaumann
+samples/bluetooth/peripheral_hr/boards/tmo_dev_edge.conf @jtbaumann
+samples/bluetooth/peripheral_ht/boards/tmo_dev_edge.conf @jtbaumann

--- a/drivers/bluetooth/custom/rs9116w/Kconfig.rs9116w
+++ b/drivers/bluetooth/custom/rs9116w/Kconfig.rs9116w
@@ -155,6 +155,20 @@ config BT_SMP_SC_PAIR_ONLY
 
 endif # BT_SMP
 
+menu "GATT Services"
+
+source "subsys/bluetooth/services/Kconfig.dis"
+
+source "subsys/bluetooth/services/Kconfig.bas"
+
+source "subsys/bluetooth/services/Kconfig.hrs"
+
+source "subsys/bluetooth/services/Kconfig.tps"
+
+source "subsys/bluetooth/services/ias/Kconfig.ias"
+
+endmenu
+
 endif # BT_CONN
 
 config BT_DEVICE_APPEARANCE

--- a/samples/bluetooth/peripheral_hr/boards/tmo_dev_edge.conf
+++ b/samples/bluetooth/peripheral_hr/boards/tmo_dev_edge.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 T-Mobile USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI=y
+CONFIG_BT_CUSTOM=y
+CONFIG_BT_RS9116W=y
+CONFIG_BT_DEBUG_LOG=n

--- a/samples/bluetooth/peripheral_ht/boards/tmo_dev_edge.conf
+++ b/samples/bluetooth/peripheral_ht/boards/tmo_dev_edge.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 T-Mobile USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI=y
+CONFIG_BT_CUSTOM=y
+CONFIG_BT_RS9116W=y
+CONFIG_BT_DEBUG_LOG=n


### PR DESCRIPTION
Enabled the usage of the pre-made services with the RS9116W bluetooth driver.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>