### PR TITLE
boards: arm: Added defines for DevEdge ADCs

### DIFF
--- a/boards/arm/tmo_dev_edge/board.h
+++ b/boards/arm/tmo_dev_edge/board.h
@@ -44,4 +44,10 @@
 #define LED_PWM_GREEN 2
 #define LED_PWM_BLUE  3
 
+#define HWID_APORT		   adcPosSelAPORT4XCH23
+#define VBAT_APORT		   adcPosSelAPORT3XCH10
+
+#define VBAT_EN_PORT       gpioPortK
+#define VBAT_EN_PIN        0
+
 #endif /* __INC_BOARD_H */


### PR DESCRIPTION
Added defines for HWID and BATMON ADCs in DevEdge board.h

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>