### PR TITLE
drivers: sensor: Fix 1PPS check on CXD5605 driver

### DIFF
--- a/drivers/sensor/cxd5605/cxd5605.c
+++ b/drivers/sensor/cxd5605/cxd5605.c
@@ -633,10 +633,8 @@ int setup_interrupts(const struct device *dev)
 	struct cxd5605_data *drv_data = dev->data;
 	const struct cxd5605_config *config = dev->config;
 	const struct gpio_dt_spec *int_gpio = &config->int_gpio;
-	char device_type[] = DT_N_P_compatible;
 
-	if (!strcmp("tmo,dev_edge", device_type)) {
-		printk("found tmo_dev_edge device\n");
+	if (config->alert_gpio.port) {
 		/* setup 1pps interrupt */
 		result = gpio_pin_configure_dt(int_gpio, GPIO_INPUT);
 
@@ -661,8 +659,6 @@ int setup_interrupts(const struct device *dev)
 		if (result < 0) {
 			return result;
 		}
-	} else {
-		printk("found tmo_tracker_v2 device\n");
 	}
 
 	return 0;


### PR DESCRIPTION
Fix 1PPS signal check to use devicetree instead of a hard-coded board check.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>