### PR TITLE
sensor: fixed ambient temperature in the lis2dw12 sensor driver.

### DIFF
--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -93,6 +93,21 @@ static inline void lis2dw12_convert(struct sensor_value *val, int raw_val, float
 	val->val2 = dval % 1000000LL;
 }
 
+static inline void lis2dw12_temperature_convert(struct sensor_value *val)
+{
+	int64_t dval;
+
+	/* Temperature output is returned in 12 bit resolution with 16LSB/degrees C scaling. */
+	float deltaT = (((int16_t)val->val1 >> LIS2DW12_SHIFT_TEMP) * LIS2DW12_TEMP_SCALE_FACTOR);
+
+	/* a value of 0 is biased at 25 degrees C. */
+	float temperature12bit = (25.0 + deltaT);
+
+	dval = ((float)temperature12bit * 10);
+	val->val1 = dval / 10LL;
+	val->val2 = (dval % 10LL) * 100000;
+}
+
 static inline void lis2dw12_channel_get_acc(const struct device *dev, enum sensor_channel chan,
 					    struct sensor_value *val)
 {
@@ -134,6 +149,9 @@ static int lis2dw12_get_ambient_temp(const struct device *dev, enum sensor_chann
 		LOG_ERR("Failed to get ambient temp");
 		return -EIO;
 	}
+
+	lis2dw12_temperature_convert(val);
+
 	return rc;
 }
 

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -65,6 +65,11 @@
 #define LIS2DW12_SHIFT_PM1     4
 #define LIS2DW12_SHIFT_PMOTHER 2
 
+/* shift value for 12 bit resolution */
+#define LIS2DW12_SHIFT_TEMP 4
+/* Temperature 12 bit scale factor */
+#define LIS2DW12_TEMP_SCALE_FACTOR 0.0625
+
 /**
  * struct lis2dw12_device_config - lis2dw12 hw configuration
  * @bus_name: Pointer to bus master identifier.


### PR DESCRIPTION
Added temperature conversion to celcius from a delta count value.

Signed-off-by: Kevin King <kevin.king101@t-mobile.com>