### PR TITLE
driver: modem: Increase size of dns buffer for 1SC

### DIFF
--- a/drivers/modem/murata-1sc.c
+++ b/drivers/modem/murata-1sc.c
@@ -1634,7 +1634,7 @@ MODEM_CMD_DEFINE(on_cmd_dnsrslv)
  */
 static int get_dns_ip(const char *dn)
 {
-	char at_cmd[64];
+	char at_cmd[128];
 	int ret;
 
 	struct modem_cmd data_cmd[] = {


### PR DESCRIPTION
This increases the buffer size for dns lookups from 64 to 128

Signed-off-by: John Lange <John.Lange2@T-Mobile.com>