### PR TITLE
modules: Fix warning in wiseconnect module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       groups:
         - hal
     - name: cxd5605_lib
-      path:  modules/hal/sony/cxd5605
+      path: modules/hal/sony/cxd5605
       url: https://github.com/tmobile/DevEdge-IoTDevKit-Sony-cxd5605.git
       revision: fd99bda2a06a9f7659b19a11534c5e1f83ffb6f1
       groups:
@@ -260,7 +260,7 @@ manifest:
       revision: e8920192b66db4f909eb9cd3f155d5245c1ae825
       path: modules/lib/uoscore-uedhoc
     - name: wiseconnect
-      revision: 8c4ad06fd958ab76e3ec5dd6dec7b1d3e1f25926
+      revision: b6993906c72709b5535cc96240f0ec552ea95e86
       path: modules/hal/silabs_wiseconnect
       url: https://github.com/tmobile/DevEdge-IoTDevKit-SiLabs-WiseConnect.git
       groups:


### PR DESCRIPTION
Updated wiseconnect module for version with fix for 'spi_is_ready' warning.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>