### PR TITLE
drivers: counter: Remove ds3231 from Gecko RTCC and add persistence

### DIFF
--- a/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
+++ b/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
@@ -18,7 +18,7 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config TIME_GECKO_RTCC
+config COUNTER_GECKO_RTCC
 	bool
 	default y
 	depends on COUNTER

--- a/boards/arm/tmo_dev_edge/Kconfig.defconfig
+++ b/boards/arm/tmo_dev_edge/Kconfig.defconfig
@@ -17,7 +17,7 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config TIME_GECKO_RTCC
+config COUNTER_GECKO_RTCC
 	bool
 	default y
 	depends on COUNTER

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Piotr Mienkowski
+ * Copyright (c) 2023 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,9 +12,12 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/posix/time.h>
 #include <soc.h>
 #include <em_cmu.h>
+#include <em_rmu.h>
 #include <em_rtcc.h>
+#include <zephyr/sys/timeutil.h>
 #include <zephyr/drivers/counter.h>
 
 #include <zephyr/logging/log.h>
@@ -219,12 +223,27 @@ static uint32_t counter_gecko_get_pending_int(const struct device *dev)
 	return 0;
 }
 
+static int update_posix(void)
+{
+	struct timespec tp;
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+	tp.tv_sec = RTCC_CounterGet();
+
+	return clock_settime(CLOCK_REALTIME, &tp);
+}
+
+/* Pin bootloader definitions. */
+#define LB_CLW0           (*((volatile uint32_t *)(LOCKBITS_BASE)+122))
+#define LB_CLW0_PINBOOTLOADER    (1 << 1)
+
 static int counter_gecko_init(const struct device *dev)
 {
 	const struct counter_gecko_config *const dev_cfg = dev->config;
+	int rc;
 
 	RTCC_Init_TypeDef rtcc_config = {
-		false,                /* Don't start counting */
+		true,                 /* Start counting when initialization is done */
 		false,                /* Disable RTC during debug halt. */
 		false,                /* Don't wrap prescaler on CCV0 */
 		true,                 /* Counter wrap on CCV1 */
@@ -279,6 +298,15 @@ static int counter_gecko_init(const struct device *dev)
 	CMU_ClockSelectSet(cmuClock_LFA, cmuSelect_LFXO);
 #endif
 
+	/* Turn off the bootloader enable bit to prevent RTCC changes */
+	LB_CLW0 &= !LB_CLW0_PINBOOTLOADER;
+
+	/* Turn on reset limited mode to preserve RTCC counts */
+	RMU_ResetControl(rmuResetWdog, rmuResetModeLimited);
+	RMU_ResetControl(rmuResetCoreLockup, rmuResetModeLimited);
+	RMU_ResetControl(rmuResetSys, rmuResetModeLimited);
+	RMU_ResetControl(rmuResetPin, rmuResetModeLimited);
+
 	/* Enable RTCC module clock */
 	CMU_ClockEnable(cmuClock_RTCC, true);
 
@@ -294,15 +322,17 @@ static int counter_gecko_init(const struct device *dev)
 	RTCC_IntDisable(_RTCC_IF_MASK);
 	RTCC_IntClear(_RTCC_IF_MASK);
 
-	/* Clear the counter */
-	RTCC->CNT = 0;
-
 	/* Configure & enable module interrupts */
 	dev_cfg->irq_config();
 
+	rc = update_posix();
+	if (rc < 0) {
+		LOG_WRN("Failed to set date: %d", rc);
+	}
+
 	LOG_INF("Device %s initialized", dev->name);
 
-	return 0;
+	return rc;
 }
 
 static const struct counter_driver_api counter_gecko_driver_api = {

--- a/drivers/counter/gecko_rtcc.c
+++ b/drivers/counter/gecko_rtcc.c
@@ -1,9 +1,5 @@
 /*
- * Copyright (c) 2019, Piotr Mienkowski
  * Copyright (c) 2022 T-Mobile USA, Inc.
- *
- * This driver is based upon merging Peter Bigot Consulting, LLC's
- * maxim_ds3231 driver with Piotr's counter_gecko_rtcc driver.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,19 +21,11 @@
 #include <zephyr/sys/timeutil.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/sys/notify.h>
-#include <zephyr/logging/log.h>
 
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(time_gecko, CONFIG_COUNTER_LOG_LEVEL);
 
 #define RTCC_MAX_VALUE       (_RTCC_CNT_MASK)
-
-enum {
-	SYNCSM_IDLE,
-	SYNCSM_PREP_READ,
-	SYNCSM_FINISH_READ,
-	SYNCSM_PREP_WRITE,
-	SYNCSM_FINISH_WRITE,
-};
 
 struct register_map {
 	uint8_t sec;
@@ -65,7 +53,7 @@ struct register_map {
 };
 
 struct counter_gecko_config {
-	struct counter_config_info generic;
+	struct counter_config_info info;
 	void (*irq_config)(void);
 	uint32_t prescaler;
 };
@@ -78,7 +66,6 @@ struct counter_gecko_alarm_data {
 struct counter_gecko_data {
 	const struct device *gecko;
 
-	struct counter_gecko_alarm_data alarm[RTCC_ALARM_NUM];
 	struct register_map registers;
 
 	struct k_sem lock;
@@ -243,9 +230,6 @@ static void validate_isw_monitoring(const struct device *dev)
 
 	if (rp->ctrl & (RTCC_IEN_CC0 | RTCC_IEN_CC1 | RTCC_IEN_CC2)) {
 		isw_mon_req |= ISW_MON_REQ_Alarm;
-	}
-	if (data->sync_state != SYNCSM_IDLE) {
-		isw_mon_req |= ISW_MON_REQ_Sync;
 	}
 	LOG_DBG("ISW : %d ?= %d", isw_mon_req, data->isw_mon_req);
 	if ((data->isw_callback != NULL)
@@ -422,7 +406,7 @@ int gecko_rtcc_get_alarm(const struct device *dev,
 	int rv = 0;
 	uint8_t addr;
 
-	if (id < cfg->generic.channels) {
+	if (id < cfg->info.channels) {
 		addr = offsetof(struct register_map, alarms[id]);
 	} else {
 		rv = -EINVAL;
@@ -482,41 +466,12 @@ static int cancel_alarm(const struct device *dev,
 
 	data->alarm_handler[id] = NULL;
 	data->alarm_user_data[id] = NULL;
-	data->alarm[id].callback = NULL;
-	data->alarm[id].user_data = NULL;
 
 	RTCC_ChannelCCVSet(id, 0);
 
 	LOG_DBG("cancel alarm: channel %u", id);
 
 	return sc_ctrl(dev, 0, RTCC_IF_CC0 << id);
-}
-
-static int counter_gecko_cancel_alarm(const struct device *dev,
-				       uint8_t id)
-{
-	struct counter_gecko_data *data = dev->data;
-	const struct counter_gecko_config *cfg = dev->config;
-	int rv = 0;
-
-	if (id >= cfg->generic.channels) {
-		rv = -EINVAL;
-		goto out;
-	}
-
-	k_sem_take(&data->lock, K_FOREVER);
-
-	rv = cancel_alarm(dev, id);
-
-	k_sem_give(&data->lock);
-
-out:
-	/* Throw away information counter API disallows */
-	if (rv >= 0) {
-		rv = 0;
-	}
-
-	return rv;
 }
 
 static int set_alarm(const struct device *dev,
@@ -534,7 +489,7 @@ static int set_alarm(const struct device *dev,
 	} else if (id == 1) {
 		addr = offsetof(struct register_map, alarms[1]);
 		len = sizeof(data->registers.alarms[1]);
-	} else if (id < cfg->generic.channels) {
+	} else if (id < cfg->info.channels) {
 		addr = offsetof(struct register_map, alarms[2]);
 		len = sizeof(data->registers.alarms[2]);
 	} else {
@@ -671,7 +626,7 @@ static void alarm_worker(struct k_work *work)
 	while (af > 0) {
 		uint8_t id;
 
-		for (id = 0; id < cfg->generic.channels; ++id) {
+		for (id = 0; id < cfg->info.channels; ++id) {
 			if ((af & (RTCC_IF_CC0 << id)) == 0) {
 				continue;
 			}
@@ -773,63 +728,6 @@ static int counter_gecko_get_value(const struct device *dev, uint32_t *ticks)
 	return rc;
 }
 
-static void sync_finish(const struct device *dev,
-			int rc)
-{
-	struct counter_gecko_data *data = dev->data;
-	struct sys_notify *notify = NULL;
-	struct k_poll_signal *signal_rcv = NULL;
-
-	if (data->sync_signal) {
-		signal_rcv = data->sync.signal;
-	} else {
-		notify = data->sync.notify;
-	}
-	data->sync.ptr = NULL;
-	data->sync_signal = false;
-	data->sync_state = SYNCSM_IDLE;
-	(void)validate_isw_monitoring(dev);
-
-	LOG_DBG("sync complete, notify %d to %p or %p\n", rc, notify, signal_rcv);
-	k_sem_give(&data->lock);
-
-	if (notify != NULL) {
-		gecko_rtcc_notify_callback cb =
-			(gecko_rtcc_notify_callback)sys_notify_finalize(notify, rc);
-
-		if (cb) {
-			cb(dev, notify, rc);
-		}
-	} else if (signal_rcv != NULL) {
-		k_poll_signal_raise(signal_rcv, rc);
-	}
-}
-
-static void sync_prep_read(const struct device *dev)
-{
-	struct counter_gecko_data *data = dev->data;
-	int rc = sc_ctrl(dev, RTCC_IEN_CNTTICK, 0U);
-
-	if (rc < 0) {
-		sync_finish(dev, rc);
-		return;
-	}
-	data->sync_state = SYNCSM_FINISH_READ;
-	validate_isw_monitoring(dev);
-}
-
-static void sync_finish_read(const struct device *dev)
-{
-	struct counter_gecko_data *data = dev->data;
-	time_t time_rcv = 0;
-
-	(void)read_time(dev, &time_rcv);
-	data->syncpoint.rtcc.tv_sec = time_rcv;
-	data->syncpoint.rtcc.tv_nsec = 0;
-	data->syncpoint.syncclock = data->isw_syncclock;
-	sync_finish(dev, 0);
-}
-
 static void sync_timer_handler(struct k_timer *tmr)
 {
 	struct counter_gecko_data *data = CONTAINER_OF(tmr,
@@ -838,121 +736,6 @@ static void sync_timer_handler(struct k_timer *tmr)
 
 	LOG_INF("sync_timer fired");
 	k_work_submit(&data->sync_work);
-}
-
-static void sync_prep_write(const struct device *dev)
-{
-	struct counter_gecko_data *data = dev->data;
-	uint32_t syncclock = gecko_rtcc_read_syncclock(dev);
-	uint32_t offset = syncclock - data->new_sp.syncclock;
-	uint32_t syncclock_Hz = gecko_rtcc_syncclock_frequency(dev);
-	uint32_t offset_s = offset / syncclock_Hz;
-	uint32_t offset_ms = (offset % syncclock_Hz) * 1000U / syncclock_Hz;
-	time_t when = data->new_sp.rtcc.tv_sec;
-
-	when += offset_s;
-	offset_ms += data->new_sp.rtcc.tv_nsec / NSEC_PER_USEC / USEC_PER_MSEC;
-	if (offset_ms >= MSEC_PER_SEC) {
-		offset_ms -= MSEC_PER_SEC;
-	} else {
-		when += 1;
-	}
-
-	uint32_t rem_ms = MSEC_PER_SEC - offset_ms;
-
-	if (rem_ms < 5) {
-		when += 1;
-		rem_ms += MSEC_PER_SEC;
-	}
-	data->new_sp.rtcc.tv_sec = when;
-	data->new_sp.rtcc.tv_nsec = 0;
-
-	data->sync_state = SYNCSM_FINISH_WRITE;
-	k_timer_start(&data->sync_timer, K_MSEC(rem_ms), K_NO_WAIT);
-	LOG_INF("sync %u in %u ms after %u", (uint32_t)when, rem_ms, syncclock);
-}
-
-static void sync_finish_write(const struct device *dev)
-{
-	struct counter_gecko_data *data = dev->data;
-	time_t when = data->new_sp.rtcc.tv_sec;
-	struct tm tm_gm;
-
-	data->registers.time = data->registers.date = 0;
-
-	(void)gmtime_r(&when, &tm_gm);
-	data->registers.sec = bin2bcd(tm_gm.tm_sec);
-	data->registers.time |= data->registers.sec << _RTCC_TIME_SECU_SHIFT;
-
-	data->registers.min = bin2bcd(tm_gm.tm_min);
-	data->registers.time |= data->registers.min << _RTCC_TIME_MINU_SHIFT;
-
-	data->registers.hour = bin2bcd(tm_gm.tm_hour);
-	data->registers.time |= data->registers.hour << _RTCC_TIME_HOURU_SHIFT;
-
-	data->registers.dow = tm_gm.tm_wday;
-	data->registers.date |= data->registers.dow << _RTCC_DATE_DAYOW_SHIFT;
-
-	data->registers.dom = bin2bcd(tm_gm.tm_mday);
-	data->registers.date |= data->registers.dom << _RTCC_DATE_DAYOMU_SHIFT;
-
-	tm_gm.tm_mon += 1;
-	data->registers.month = bin2bcd(tm_gm.tm_mon);
-	data->registers.date |= data->registers.month << _RTCC_DATE_MONTHU_SHIFT;
-
-	if (tm_gm.tm_year >= 100) {
-		RTCC->RET[0].REG = tm_gm.tm_year / 100;
-		tm_gm.tm_year %= 100;
-	}
-
-	data->registers.year = bin2bcd(tm_gm.tm_year);
-	data->registers.date |= data->registers.year << _RTCC_DATE_YEARU_SHIFT;
-
-	uint32_t syncclock = gecko_rtcc_read_syncclock(dev);
-
-	RTCC_TimeSet(data->registers.time);
-	RTCC_DateSet(data->registers.date);
-
-	data->syncpoint.rtcc.tv_sec = when;
-	data->syncpoint.rtcc.tv_nsec = 0;
-	data->syncpoint.syncclock = syncclock;
-	LOG_INF("sync %u at %u", (uint32_t)when, syncclock);
-
-	sync_finish(dev, 0);
-}
-
-static void sync_worker(struct k_work *work)
-{
-	struct counter_gecko_data *data = CONTAINER_OF(work, struct counter_gecko_data, sync_work);
-	uint32_t syncclock = gecko_rtcc_read_syncclock(data->gecko);
-	bool unlock = true;
-
-	k_sem_take(&data->lock, K_FOREVER);
-
-	LOG_DBG("SYNC.%u %u latency %u", data->sync_state, data->isw_syncclock,
-		syncclock - data->isw_syncclock);
-	switch (data->sync_state) {
-	default:
-	case SYNCSM_IDLE:
-		break;
-	case SYNCSM_PREP_READ:
-		sync_prep_read(data->gecko);
-		break;
-	case SYNCSM_FINISH_READ:
-		sync_finish_read(data->gecko);
-		break;
-	case SYNCSM_PREP_WRITE:
-		sync_prep_write(data->gecko);
-		break;
-	case SYNCSM_FINISH_WRITE:
-		sync_finish_write(data->gecko);
-		unlock = false;
-		break;
-	}
-
-	if (unlock) {
-		k_sem_give(&data->lock);
-	}
 }
 
 static void isw_rtcc_callback(const struct device *dev,
@@ -965,8 +748,6 @@ static void isw_rtcc_callback(const struct device *dev,
 	data->isw_syncclock = gecko_rtcc_read_syncclock(data->gecko);
 	if (data->registers.ctrl & RTCC_IEN_CNTTICK) {
 		k_work_submit(&data->alarm_work);
-	} else if (data->sync_state != SYNCSM_IDLE) {
-		k_work_submit(&data->sync_work);
 	} else {
 		k_work_submit(&data->sqw_work);
 	}
@@ -1010,21 +791,8 @@ int gecko_rtcc_synchronize(const struct device *dev,
 
 	k_sem_take(&data->lock, K_FOREVER);
 
-	if (data->sync_state != SYNCSM_IDLE) {
-		rv = -EBUSY;
-		goto out_locked;
-	}
-
 	data->sync_signal = false;
 	data->sync.notify = notify;
-	data->sync_state = SYNCSM_PREP_READ;
-
-out_locked:
-	k_sem_give(&data->lock);
-
-	if (rv >= 0) {
-		k_work_submit(&data->sync_work);
-	}
 
 out:
 	return rv;
@@ -1043,21 +811,8 @@ int z_impl_gecko_rtcc_req_syncpoint(const struct device *dev,
 
 	k_sem_take(&data->lock, K_FOREVER);
 
-	if (data->sync_state != SYNCSM_IDLE) {
-		rv = -EBUSY;
-		goto out_locked;
-	}
-
 	data->sync_signal = true;
 	data->sync.signal = sig;
-	data->sync_state = SYNCSM_PREP_READ;
-
-out_locked:
-	k_sem_give(&data->lock);
-
-	if (rv >= 0) {
-		k_work_submit(&data->sync_work);
-	}
 
 out:
 	return rv;
@@ -1082,22 +837,9 @@ int gecko_rtcc_set(const struct device *dev,
 
 	k_sem_take(&data->lock, K_FOREVER);
 
-	if (data->sync_state != SYNCSM_IDLE) {
-		rv = -EBUSY;
-		goto out_locked;
-	}
-
 	data->new_sp = *syncpoint;
 	data->sync_signal = false;
 	data->sync.notify = notify;
-	data->sync_state = SYNCSM_PREP_WRITE;
-
-out_locked:
-	k_sem_give(&data->lock);
-
-	if (rv >= 0) {
-		k_work_submit(&data->sync_work);
-	}
 
 out:
 	return rv;
@@ -1213,7 +955,6 @@ static int counter_gecko_init(const struct device *dev)
 	k_timer_init(&data->sync_timer, sync_timer_handler, NULL);
 	k_work_init(&data->alarm_work, alarm_worker);
 	k_work_init(&data->sqw_work, sqw_worker);
-	k_work_init(&data->sync_work, sync_worker);
 	data->isw_callback = isw_rtcc_callback;
 
 	rc = update_registers(dev);
@@ -1239,116 +980,8 @@ out:
 	return rc;
 }
 
-static int counter_gecko_start(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return -EALREADY;
-}
-
-static int counter_gecko_stop(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return -ENOTSUP;
-}
-
-static int counter_gecko_set_alarm(const struct device *dev, uint8_t id,
-				   const struct counter_alarm_cfg *alarm_cfg)
-{
-	struct counter_gecko_data *data = dev->data;
-	const struct counter_gecko_config *cfg = dev->config;
-	time_t when;
-	int rc = 0;
-
-	if (id >= cfg->generic.channels) {
-		rc = -ENOTSUP;
-		goto out;
-	}
-
-	k_sem_take(&data->lock, K_FOREVER);
-
-	if (data->alarm[id].callback != NULL) {
-		rc = -EBUSY;
-		goto out_locked;
-	}
-
-	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
-		rc = read_time(dev, &when);
-		if (rc >= 0) {
-			when += alarm_cfg->ticks;
-		}
-	} else {
-		when = alarm_cfg->ticks;
-	}
-
-	RTCC_IntClear(RTCC_IF_CC0 << id);
-
-	data->alarm[id].callback = alarm_cfg->callback;
-	data->alarm[id].user_data = alarm_cfg->user_data;
-
-	RTCC_ChannelCCVSet(id, when);
-
-	/* Enable the compare interrupt */
-	RTCC_IntEnable(RTCC_IF_CC0 << id);
-
-	struct gecko_rtcc_alarm alarm = {
-		.time = (uint32_t)when,
-		.handler = counter_alarm_forwarder,
-		.user_data = alarm_cfg->user_data,
-		.flags = 0,
-	};
-
-	if (rc >= 0) {
-		data->alarm_handler[id] = alarm_cfg->callback;
-		data->counter_ticks[id] = alarm.time;
-		rc = set_alarm(dev, id, &alarm);
-	}
-
-out_locked:
-	k_sem_give(&data->lock);
-
-out:
-	/* Throw away information counter API disallows */
-	if (rc >= 0) {
-		rc = 0;
-	}
-
-	return rc;
-}
-
-static uint32_t counter_gecko_get_top_value(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return UINT32_MAX;
-}
-
-static uint32_t counter_gecko_get_pending_int(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-static int counter_gecko_set_top_value(const struct device *dev,
-				       const struct counter_top_cfg *cfg)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cfg);
-
-	return -ENOTSUP;
-}
-
 static const struct counter_driver_api counter_gecko_driver_api = {
-	.start = counter_gecko_start,
-	.stop = counter_gecko_stop,
 	.get_value = counter_gecko_get_value,
-	.set_alarm = counter_gecko_set_alarm,
-	.cancel_alarm = counter_gecko_cancel_alarm,
-	.set_top_value = counter_gecko_set_top_value,
-	.get_pending_int = counter_gecko_get_pending_int,
-	.get_top_value = counter_gecko_get_top_value,
 };
 
 /* RTCC0 */
@@ -1385,7 +1018,7 @@ static void counter_gecko_0_irq_config(void)
 }
 
 static const struct counter_gecko_config counter_gecko_0_config = {
-	.generic = {
+	.info = {
 		.max_top_value = RTCC_MAX_VALUE,
 		.freq = 1,
 		.flags = COUNTER_CONFIG_INFO_COUNT_UP,
@@ -1401,42 +1034,3 @@ DEVICE_DT_INST_DEFINE(0, counter_gecko_init, NULL,
 	&counter_gecko_0_data, &counter_gecko_0_config,
 	PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY,
 	&counter_gecko_driver_api);
-
-#ifdef CONFIG_USERSPACE
-
-#include <zephyr/syscall_handler.h>
-
-int z_vrfy_gecko_rtcc_get_syncpoint(const struct device *dev,
-				      struct gecko_rtcc_syncpoint *syncpoint)
-{
-	struct gecko_rtcc_syncpoint value;
-	int rv;
-
-	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_COUNTER, &counter_gecko_driver_api));
-	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(syncpoint, sizeof(*syncpoint)));
-
-	rv = z_impl_gecko_rtcc_get_syncpoint(dev, &value);
-
-	if (rv >= 0) {
-		Z_OOPS(z_user_to_copy(syncpoint, &value, sizeof(*syncpoint)));
-	}
-
-	return rv;
-}
-
-#include <syscalls/gecko_rtcc_get_syncpoint_mrsh.c>
-
-int z_vrfy_gecko_rtcc_req_syncpoint(const struct device *dev,
-				      struct k_poll_signal *sig)
-{
-	Z_OOPS(Z_SYSCALL_SPECIFIC_DRIVER(dev, K_OBJ_DRIVER_COUNTER, &counter_gecko_driver_api));
-	if (sig != NULL) {
-		Z_OOPS(Z_SYSCALL_OBJ(sig, K_OBJ_POLL_SIGNAL));
-	}
-
-	return z_impl_gecko_rtcc_req_syncpoint(dev, sig);
-}
-
-#include <syscalls/gecko_rtcc_req_syncpoint_mrsh.c>
-
-#endif /* CONFIG_USERSPACE */

--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Nick Ward
+ * Copyright (c) 2022 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +11,13 @@
 #include <string.h>
 #include <zephyr/posix/time.h>
 #include <zephyr/sys/timeutil.h>
+#include <zephyr/drivers/counter.h>
+#if defined(CONFIG_COUNTER_GECKO_RTCC)
+#include <em_rtcc.h>
+#endif
+#if defined(CONFIG_TIME_GECKO_RTCC)
+#include <em_rtcc.h>
+#endif
 
 #define HELP_NONE      "[none]"
 #define HELP_DATE_SET  "[Y-m-d] <H:M:S>"
@@ -138,6 +146,11 @@ static int get_h_m_s(const struct shell *shell, struct tm *tm, char *time_str)
 
 static int cmd_date_set(const struct shell *shell, size_t argc, char **argv)
 {
+#if defined(CONFIG_TIME_GECKO_RTCC)
+	uint32_t time_set = 0;    /*!< RTCC_TIME - Time of Day Register */
+	uint32_t date_set = 0;    /*!< RTCC_DATE - Date Register */
+	uint32_t year_set = 0;
+#endif
 	struct timespec tp;
 	struct tm tm;
 	int ret;
@@ -181,6 +194,29 @@ static int cmd_date_set(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_TIME_GECKO_RTCC)
+	time_set |= bin2bcd(tm.tm_sec) << _RTCC_TIME_SECU_SHIFT;
+	time_set |= bin2bcd(tm.tm_min) << _RTCC_TIME_MINU_SHIFT;
+	time_set |= bin2bcd(tm.tm_hour) << _RTCC_TIME_HOURU_SHIFT;
+	date_set |= tm.tm_wday << _RTCC_DATE_DAYOW_SHIFT;
+	date_set |= bin2bcd(tm.tm_mday) << _RTCC_DATE_DAYOMU_SHIFT;
+	date_set |= bin2bcd(tm.tm_mon) << _RTCC_DATE_MONTHU_SHIFT;
+
+	year_set = tm.tm_year;
+	if (year_set >= 100) {
+		RTCC->RET[0].REG = year_set / 100;
+		year_set %= 100;
+	}
+
+	date_set |= bin2bcd(year_set) << _RTCC_DATE_YEARU_SHIFT;
+
+	RTCC_TimeSet(time_set);
+	RTCC_DateSet(date_set);
+#endif
+#if defined(CONFIG_COUNTER_GECKO_RTCC)
+	RTCC_CounterSet(tp.tv_sec);
+#endif
+
 	date_print(shell, &tm);
 
 	return 0;
@@ -200,9 +236,56 @@ static int cmd_date_get(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+#if defined(CONFIG_COUNTER_GECKO_RTCC)
+#define TIMER_COUNTER DT_NODELABEL(rtcc0)
+#endif
+#if defined(CONFIG_TIME_GECKO_RTCC)
+#define TIMER_COUNTER DT_NODELABEL(rtcc0)
+#endif
+
+static int cmd_counter_get(const struct shell *shell_ptr, size_t argc, char **argv)
+{
+#ifdef TIMER_COUNTER
+	const struct device *const counter_dev = DEVICE_DT_GET(TIMER_COUNTER);
+	uint32_t ticks;
+	struct tm tm_gm;
+	int err;
+
+	if (counter_dev == NULL) {
+		shell_error(shell_ptr, "Counter not found");
+		return -EINVAL;
+	}
+
+	err = counter_get_value(counter_dev, &ticks);
+	if (err) {
+		shell_error(shell_ptr, "Failed to read counter value (err %d)", err);
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_TIME_GECKO_RTCC)
+	time_t time_ticks = (time_t)ticks;
+	gmtime_r(&time_ticks, &tm_gm);
+
+	date_print(shell_ptr, &tm_gm);
+#else
+	struct timespec tp;
+
+	tp.tv_sec = ticks;
+
+	gmtime_r(&tp.tv_sec, &tm_gm);
+
+	date_print(shell_ptr, &tm_gm);
+#endif
+#else
+	shell_print(shell_ptr, "Counter not defined");
+#endif
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_date,
 	SHELL_CMD(set, NULL, HELP_DATE_SET, cmd_date_set),
 	SHELL_CMD(get, NULL, HELP_NONE, cmd_date_get),
+	SHELL_CMD(counter, NULL, HELP_NONE, cmd_counter_get),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -264,6 +264,7 @@ static int cmd_counter_get(const struct shell *shell_ptr, size_t argc, char **ar
 
 #if defined(CONFIG_TIME_GECKO_RTCC)
 	time_t time_ticks = (time_t)ticks;
+
 	gmtime_r(&time_ticks, &tm_gm);
 
 	date_print(shell_ptr, &tm_gm);


### PR DESCRIPTION
Switch TIME_GECKO_RTCC back to COUNTER_GECKO_RTCC
They should be interchangeable now
Add persistence to SiLab's counter_gecko_rtcc.c
Remove most of ds3231 references from my gecko_rtcc.c file Fix date_service mistake with TIMER vs TIMER_COUNTER Add sections for CONFIG_COUNTER_GECKO_RTCC differences

Signed-off-by: Dennis Ruffer <Dennis.Ruffer1@T-Mobile.com>