### PR TITLE
drivers: counter: Re-add date_service persistence and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -176,6 +176,7 @@ subsys/net/lib/Kconfig merge=ours
 subsys/net/lib/ping/CMakeLists.txt merge=ours
 subsys/net/lib/ping/Kconfig merge=ours
 subsys/net/lib/ping/ping.c merge=ours
+subsys/shell/modules/date_service.c=ours
 subsys/shell/shell_help.c merge=ours
 subsys/shell/shell_ops.c merge=ours
 tests/drivers/counter/counter_basic_api/boards/efm32pg_stk3402a.conf merge=ours

--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Nick Ward
+ * Copyright (c) 2022 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +11,13 @@
 #include <string.h>
 #include <zephyr/posix/time.h>
 #include <zephyr/sys/timeutil.h>
+#include <zephyr/drivers/counter.h>
+#if defined(CONFIG_COUNTER_GECKO_RTCC)
+#include <em_rtcc.h>
+#endif
+#if defined(CONFIG_TIME_GECKO_RTCC)
+#include <em_rtcc.h>
+#endif
 
 #define HELP_NONE      "[none]"
 #define HELP_DATE_SET  "[Y-m-d] <H:M:S>"
@@ -138,6 +146,11 @@ static int get_h_m_s(const struct shell *shell, struct tm *tm, char *time_str)
 
 static int cmd_date_set(const struct shell *shell, size_t argc, char **argv)
 {
+#if defined(CONFIG_TIME_GECKO_RTCC)
+	uint32_t time_set = 0;    /*!< RTCC_TIME - Time of Day Register */
+	uint32_t date_set = 0;    /*!< RTCC_DATE - Date Register */
+	uint32_t year_set = 0;
+#endif
 	struct timespec tp;
 	struct tm tm;
 	int ret;
@@ -181,6 +194,29 @@ static int cmd_date_set(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_TIME_GECKO_RTCC)
+	time_set |= bin2bcd(tm.tm_sec) << _RTCC_TIME_SECU_SHIFT;
+	time_set |= bin2bcd(tm.tm_min) << _RTCC_TIME_MINU_SHIFT;
+	time_set |= bin2bcd(tm.tm_hour) << _RTCC_TIME_HOURU_SHIFT;
+	date_set |= tm.tm_wday << _RTCC_DATE_DAYOW_SHIFT;
+	date_set |= bin2bcd(tm.tm_mday) << _RTCC_DATE_DAYOMU_SHIFT;
+	date_set |= bin2bcd(tm.tm_mon) << _RTCC_DATE_MONTHU_SHIFT;
+
+	year_set = tm.tm_year;
+	if (year_set >= 100) {
+		RTCC->RET[0].REG = year_set / 100;
+		year_set %= 100;
+	}
+
+	date_set |= bin2bcd(year_set) << _RTCC_DATE_YEARU_SHIFT;
+
+	RTCC_TimeSet(time_set);
+	RTCC_DateSet(date_set);
+#endif
+#if defined(CONFIG_COUNTER_GECKO_RTCC)
+	RTCC_CounterSet(tp.tv_sec);
+#endif
+
 	date_print(shell, &tm);
 
 	return 0;
@@ -200,9 +236,57 @@ static int cmd_date_get(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+#if defined(CONFIG_COUNTER_GECKO_RTCC)
+#define TIMER_COUNTER DT_NODELABEL(rtcc0)
+#endif
+#if defined(CONFIG_TIME_GECKO_RTCC)
+#define TIMER_COUNTER DT_NODELABEL(rtcc0)
+#endif
+
+static int cmd_counter_get(const struct shell *shell_ptr, size_t argc, char **argv)
+{
+#ifdef TIMER_COUNTER
+	const struct device *const counter_dev = DEVICE_DT_GET(TIMER_COUNTER);
+	uint32_t ticks;
+	struct tm tm_gm;
+	int err;
+
+	if (counter_dev == NULL) {
+		shell_error(shell_ptr, "Counter not found");
+		return -EINVAL;
+	}
+
+	err = counter_get_value(counter_dev, &ticks);
+	if (err) {
+		shell_error(shell_ptr, "Failed to read counter value (err %d)", err);
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_TIME_GECKO_RTCC)
+	time_t time_ticks = (time_t)ticks;
+
+	gmtime_r(&time_ticks, &tm_gm);
+
+	date_print(shell_ptr, &tm_gm);
+#else
+	struct timespec tp;
+
+	tp.tv_sec = ticks;
+
+	gmtime_r(&tp.tv_sec, &tm_gm);
+
+	date_print(shell_ptr, &tm_gm);
+#endif
+#else
+	shell_print(shell_ptr, "Counter not defined");
+#endif
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_date,
 	SHELL_CMD(set, NULL, HELP_DATE_SET, cmd_date_set),
 	SHELL_CMD(get, NULL, HELP_NONE, cmd_date_get),
+	SHELL_CMD(counter, NULL, HELP_NONE, cmd_counter_get),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 


### PR DESCRIPTION
Fix date_service mistake with TIMER vs TIMER_COUNTER. Add sections for CONFIG_COUNTER_GECKO_RTCC differences. Add this file to .gitattributes so we consider this as ours.

Signed-off-by: Dennis Ruffer <Dennis.Ruffer1@T-Mobile.com>