### PR TITLE
driver: sensor: Fix assert error in cxd driver

### DIFF
--- a/drivers/sensor/cxd5605/cxd5605.c
+++ b/drivers/sensor/cxd5605/cxd5605.c
@@ -712,7 +712,7 @@ static int cxd5605_driver_pm_action(const struct device *dev,
 		 * domain this device belongs is suspended.
 		 */
 
-		gpio_pin_configure_dt(&config->int_gpio, GPIO_INT_DISABLE);
+		gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_DISABLE);
 		result = gpio_pin_configure_dt(pwr_gpio, GPIO_OUTPUT_LOW);
 		result = gpio_pin_configure_dt(rst_gpio, GPIO_OUTPUT_LOW);
 		break;


### PR DESCRIPTION
Fixed issue where an assert would be raised if the off command was called in the cxd5605 driver.