### PR TITLE
driver: bluetooth: Handle long configured names

### DIFF
--- a/drivers/bluetooth/custom/rs9116w/Kconfig.rs9116w
+++ b/drivers/bluetooth/custom/rs9116w/Kconfig.rs9116w
@@ -182,7 +182,7 @@ config BT_DEVICE_APPEARANCE
 
 config BT_DEBUG
 	bool "Bluetooth driver debug"
-	default y
+	default n
 	help
 	  This option enables debug support for the RS9116W
 	  Bluetooth driver.

--- a/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.c
+++ b/drivers/bluetooth/custom/rs9116w/rs9116w_ble_core.c
@@ -94,11 +94,19 @@ int bt_enable(bt_ready_cb_t cb)
 
 	device_init();
 
-	err = rsi_bt_set_local_name(CONFIG_BT_DEVICE_NAME);
+	char name[17] = {0};
+
+	if (strlen(CONFIG_BT_DEVICE_NAME) > 16) {
+		BT_WARN("Configured name is too long, truncating to 16 bytes");
+	}
+
+	strncpy(name, CONFIG_BT_DEVICE_NAME, 16);
+
+	err = rsi_bt_set_local_name(name);
 	if (err) {
 		BT_ERR("Name set fail: 0x%X\n", err);
 	} else {
-		BT_INFO("Device name set to: %s\n", CONFIG_BT_DEVICE_NAME);
+		BT_INFO("Device name set to: %s\n", name);
 	}
 
 	/*spawn the thread*/


### PR DESCRIPTION
Fixed 9116 driver to better handle names longer than 16bytes.