### PR TITLE
drivers: sensor: Fix LIS2DW12 const issue

### DIFF
--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -632,7 +632,7 @@ static int lis2dw12_pm_action(const struct device *dev,
 {
 	int ret = 0;
 	struct lis2dw12_data *data = dev->data;
-	struct lis2dw12_device_config *cfg = dev->config;
+	const struct lis2dw12_device_config *cfg = dev->config;
 
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
This fixes a small issue where a variable needs to be declared const