### PR TITLE
Add threshold interrupt support to TSL2540 driver

### DIFF
--- a/drivers/sensor/tsl2540/tsl2540.h
+++ b/drivers/sensor/tsl2540/tsl2540.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 T-Mobile USA, Inc.
+ * Copyright (c) 2023 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,7 +13,6 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor/tsl2540.h>
 
-#define TSL2540_REG_EN	     0x80
 #define TSL2540_REG_ATIME    0x81
 #define TSL2540_REG_WTIME    0x83
 #define TSL2540_REG_AILT_LOW 0x84
@@ -25,15 +25,12 @@
 #define TSL2540_REG_REVID    0x91
 #define TSL2540_REG_ID	     0x92
 #define TSL2540_REG_STATUS   0x93
-#define TSL2540_REG_VIS_HI   0x94
-#define TSL2540_REG_VIS_LOW  0x95
-#define TSL2540_REG_IR_HI    0x96
-#define TSL2540_REG_IR_LOW   0x97
+#define TSL2540_REG_VIS_LOW  0x94
+#define TSL2540_REG_VIS_HI   0x95
+#define TSL2540_REG_IR_LOW   0x96
+#define TSL2540_REG_IR_HI    0x97
 #define TSL2540_REG_REVID2   0x9E
 #define TSL2540_REG_CFG_2    0x9f
-#define TSL2540_REG_CFG_3    0xab
-#define TSL2540_REG_AZ_CFG   0xd6
-#define TSL2540_REG_INT_EN   0xdd
 
 #define TSL2540_AGAIN_S1_2 0.5
 #define TSL2540_AGAIN_S1   1
@@ -49,10 +46,6 @@
 #define TSL2540_CFG1_G64  0x03
 #define TSL2540_CFG1_G128 0x03
 
-#define TSL2540_EN_ACTIVE 0x03
-#define TSL2540_EN_IDLE	  0x01
-#define TSL2540_EN_SLEEP  0x00
-
 #define TSL2540_CFG2_G1_2 0x00
 #define TSL2540_CFG2_G1	  0x04
 #define TSL2540_CFG2_G4	  0x04
@@ -60,7 +53,22 @@
 #define TSL2540_CFG2_G64  0x04
 #define TSL2540_CFG2_G128 0x14
 
-#define TSL2540_INT_EN_AEN 0x10
+/* ENABLE(0x80: 0x00): Reserved:7:4 | WEN:3 | Reserved:2 | AEN:1 | PON:0 */
+#define TSL2540_ENABLE_ADDR 0x80
+#define TSL2540_ENABLE_MASK ((0000 << 4) | (1 << 3) | (0 << 2) | (1 << 1) | (1 << 0))
+#define TSL2540_ENABLE_CONF ((0000 << 4) | (1 << 3) | (0 << 2) | (1 << 1) | (1 << 0))
+
+/* CRG3(0xAB: 0x0C):  INT_READ_CLEAR:7 | Reserved:6:5 | SAI:4 | Reserved:3:0 */
+#define TSL2540_CFG3_ADDR 0xAB
+#define TSL2540_CFG3_MASK ((1 << 7) | (00 << 5) | (1 << 4) | (0000 << 0))
+#define TSL2540_CFG3_CONF ((0 << 7) | (00 << 5) | (1 << 4) | (0000 << 0))
+
+/* INTENAB(0xDD: 0x00): ASIEN:7 | Reserved:6:5 | AIEN:4 | Reserved:3:0 */
+#define TSL2540_INTENAB_ADDR 0xDD
+#define TSL2540_INTENAB_MASK ((1 << 7) | (00 < 5) | (1 << 4) | (0000 << 0))
+#define TSL2540_INTENAB_CONF ((0 << 7) | (00 < 5) | (1 << 4) | (0000 << 0))
+
+#define TSL2540_INT_EN_AEN 0x90
 
 struct tsl2540_config {
 	const struct i2c_dt_spec i2c_spec;
@@ -72,10 +80,7 @@ struct tsl2540_data {
 	struct k_sem sem;
 #ifdef CONFIG_TSL2540_TRIGGER
 	const struct device *dev;
-	const struct device *gpio;
-	uint8_t gpio_pin;
 	struct gpio_callback gpio_cb;
-	enum interrupt_type int_type;
 	sensor_trigger_handler_t als_handler;
 #endif
 #ifdef CONFIG_TSL2540_TRIGGER_OWN_THREAD
@@ -100,8 +105,7 @@ int tsl2540_reg_write(const struct device *dev, uint8_t reg, uint8_t val);
 #ifdef CONFIG_TSL2540_TRIGGER
 int tsl2540_trigger_init(const struct device *dev);
 
-int tsl2540_trigger_set(const struct device *dev,
-			const struct sensor_trigger *trig,
+int tsl2540_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handler);
 #endif
 

--- a/drivers/sensor/tsl2540/tsl2540_trigger.c
+++ b/drivers/sensor/tsl2540/tsl2540_trigger.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 T-Mobile USA, Inc.
+ * Copyright (c) 2023 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,9 +12,6 @@ LOG_MODULE_DECLARE(tsl2540, CONFIG_SENSOR_LOG_LEVEL);
 
 static void tsl2540_handle_cb(struct tsl2540_data *data)
 {
-	gpio_pin_interrupt_configure(data->gpio, data->gpio_pin,
-				     GPIO_INT_DISABLE);
-
 #if defined(CONFIG_TSL2540_TRIGGER_OWN_THREAD)
 	k_sem_give(&data->trig_sem);
 #elif defined(CONFIG_TSL2540_TRIGGER_GLOBAL_THREAD)
@@ -21,45 +19,62 @@ static void tsl2540_handle_cb(struct tsl2540_data *data)
 #endif
 }
 
-static void tsl2540_gpio_callback(const struct device *dev,
-				   struct gpio_callback *cb,
-				   uint32_t pin_mask)
+static void tsl2540_gpio_callback(const struct device *dev, struct gpio_callback *cb,
+				  uint32_t pin_mask)
 {
-	struct tsl2540_data *data =
-		CONTAINER_OF(cb, struct tsl2540_data, gpio_cb);
+	struct tsl2540_data *data = CONTAINER_OF(cb, struct tsl2540_data, gpio_cb);
+	const struct tsl2540_config *config = data->dev->config;
 
-	if ((pin_mask & BIT(data->gpio_pin)) == 0U) {
+	if ((pin_mask & BIT(config->int_gpio.pin)) == 0U) {
 		return;
 	}
 
 	tsl2540_handle_cb(data);
 }
 
-
 static void tsl2540_handle_int(const struct device *dev)
 {
-	struct tsl2540_data *data = dev->data;
+	int ret;
 	uint8_t status;
 
-	k_sem_take(&data->sem, K_FOREVER);
+	ret = tsl2540_reg_read(dev, TSL2540_REG_STATUS, &status);
+	if (ret) {
+		LOG_ERR("Could not read status register (%#x), errno: %d", TSL2540_REG_STATUS, ret);
+	} else {
+		if ((1 << 7) & status) { /* ASAT */
+			/*
+			 * TODO:
+			 * Implement a mechanism triggered by the over-saturation of one or
+			 * both input amplifiers to automatically adjust the input gain to
+			 * keep the amplifiers from saturating.
+			 */
 
-	if (tsl2540_read(dev, TSL2540_REG_STATUS, &status)) {
-		LOG_ERR("Could not read status");
+			LOG_ERR("Interrupt status(%#x): %#x: ASAT", TSL2540_REG_STATUS, status);
+		}
+		if ((1 << 3) & status) { /* CINT */
+			LOG_INF("Interrupt status(%#x): %#x: CINT", TSL2540_REG_STATUS, status);
+		}
+		if ((1 << 4) & status) { /* AINT */
+			struct tsl2540_data *data = dev->data;
+
+			LOG_INF("Interrupt status(%#x): %#x: AINT", TSL2540_REG_STATUS, status);
+			if (data->als_handler) {
+				/*
+				 * TODO: Consider fetching the illuminance data and making it
+				 * available to the application; for example:
+				 *
+				 *	k_sem_take(&data->sem, K_FOREVER);
+				 *	...
+				 *	k_sem_give(&data->sem);
+				 */
+
+				data->als_handler(
+					dev, &(struct sensor_trigger){.type = SENSOR_TRIG_THRESHOLD,
+								      .chan = SENSOR_CHAN_LIGHT});
+			}
+			tsl2540_reg_write(dev, TSL2540_REG_STATUS, status);
+		}
 	}
-
-	k_sem_give(&data->sem);
-
-	struct sensor_trigger als_trig = {
-		.type = SENSOR_TRIG_THRESHOLD,
-		.chan = SENSOR_CHAN_LIGHT,
-	};
-
-	if (data->als_handler) {
-		data->als_handler(dev, &als_trig);
-	}
-
-	gpio_pin_interrupt_configure(data->gpio, data->gpio_pin,
-				     GPIO_INT_EDGE_TO_ACTIVE);
 }
 
 #ifdef CONFIG_TSL2540_TRIGGER_OWN_THREAD
@@ -75,52 +90,51 @@ static void tsl2540_thread_main(struct tsl2540_data *data)
 #ifdef CONFIG_TSL2540_TRIGGER_GLOBAL_THREAD
 static void tsl2540_work_handler(struct k_work *work)
 {
-	struct tsl2540_data *data =
-		CONTAINER_OF(work, struct tsl2540_data, work);
+	struct tsl2540_data *data = CONTAINER_OF(work, struct tsl2540_data, work);
 
 	tsl2540_handle_int(data->dev);
 }
 #endif
 
-int tsl2540_trigger_set(const struct device *dev,
-			 const struct sensor_trigger *trig,
-			 sensor_trigger_handler_t handler)
+int tsl2540_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler)
 {
-	struct tsl2540_data *data = dev->data;
-	uint8_t conf;
-	int ret = 0;
+	int ret;
 
-	k_sem_take(&data->sem, K_FOREVER);
+	if (trig->chan == SENSOR_CHAN_LIGHT) {
+		switch (trig->type) {
+		case SENSOR_TRIG_THRESHOLD: {
+			const struct i2c_dt_spec *i2c_spec =
+				&((const struct tsl2540_config *)dev->config)->i2c_spec;
 
-	switch (trig->type) {
-	case SENSOR_TRIG_THRESHOLD:
-		if (trig->chan == SENSOR_CHAN_LIGHT) {
-			if (tsl2540_reg_read(dev, TSL2540_REG_INT_EN, &conf)) {
-				ret = -EIO;
-				goto exit;
+			ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_INTENAB_ADDR,
+						       TSL2540_INTENAB_MASK, TSL2540_INTENAB_CONF);
+			if (ret) {
+				LOG_ERR("%#x: I/O error: %d", TSL2540_INTENAB_ADDR, ret);
+			} else {
+				ret = i2c_reg_update_byte_dt(i2c_spec, TSL2540_CFG3_ADDR,
+							     TSL2540_CFG3_MASK, TSL2540_CFG3_CONF);
+				if (ret) {
+					LOG_ERR("%#x: I/O error: %d", TSL2540_CFG3_ADDR, ret);
+				} else {
+					struct tsl2540_data *data = dev->data;
+
+					k_sem_take(&data->sem, K_FOREVER);
+					data->als_handler = handler;
+					k_sem_give(&data->sem);
+				}
 			}
+		} break;
 
-			/* Set interrupt enable bit */
-			conf |= TSL2540_INT_EN_AEN;
-
-			if (tsl2540_reg_write(dev, TSL2540_REG_INT_EN, conf)) {
-				ret = -EIO;
-				goto exit;
-			}
-
-			data->als_handler = handler;
-		} else {
+		default:
 			ret = -ENOTSUP;
-			goto exit;
+			LOG_ERR("Unsupported sensor trigger type: %d", trig->type);
+			break;
 		}
-		break;
-	default:
-		LOG_ERR("Unsupported sensor trigger");
+	} else {
 		ret = -ENOTSUP;
-		goto exit;
+		LOG_ERR("Unsupported sensor trigger channel: %d", trig->chan);
 	}
-exit:
-	k_sem_give(&data->sem);
 
 	return ret;
 }
@@ -134,12 +148,9 @@ int tsl2540_trigger_init(const struct device *dev)
 
 #if defined(CONFIG_TSL2540_TRIGGER_OWN_THREAD)
 	k_sem_init(&data->trig_sem, 0, K_SEM_MAX_LIMIT);
-	k_thread_create(&data->thread, data->thread_stack,
-			CONFIG_TSL2540_THREAD_STACK_SIZE,
-			(k_thread_entry_t)tsl2540_thread_main,
-			data, NULL, NULL,
-			K_PRIO_COOP(CONFIG_TSL2540_THREAD_PRIORITY),
-			0, K_NO_WAIT);
+	k_thread_create(&data->thread, data->thread_stack, CONFIG_TSL2540_THREAD_STACK_SIZE,
+			(k_thread_entry_t)tsl2540_thread_main, data, NULL, NULL,
+			K_PRIO_COOP(CONFIG_TSL2540_THREAD_PRIORITY), 0, K_NO_WAIT);
 	k_thread_name_set(&data->thread, "TSL2540 trigger");
 #elif defined(CONFIG_TSL2540_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = tsl2540_work_handler;
@@ -147,28 +158,39 @@ int tsl2540_trigger_init(const struct device *dev)
 
 	/* Get the GPIO device */
 	if (!device_is_ready(config->int_gpio.port)) {
-		LOG_ERR("tsl2540: gpio controller %s not ready",
-			config->int_gpio.port->name);
+		LOG_ERR("%s: gpio controller %s not ready", dev->name, config->int_gpio.port->name);
 		return -ENODEV;
 	}
 
-	data->gpio_pin = config->int_gpio.pin;
+	gpio_pin_configure_dt(&config->int_gpio, GPIO_INPUT);
 
-	gpio_pin_configure(data->gpio, data->gpio_pin,
-			   GPIO_INPUT | config->int_gpio.dt_flags);
+	gpio_init_callback(&data->gpio_cb, tsl2540_gpio_callback, BIT(config->int_gpio.pin));
 
-	gpio_init_callback(&data->gpio_cb, tsl2540_gpio_callback,
-			   BIT(data->gpio_pin));
-
-	if (gpio_add_callback(data->gpio, &data->gpio_cb) < 0) {
+	if (gpio_add_callback(config->int_gpio.port, &data->gpio_cb) < 0) {
 		LOG_DBG("Failed to set gpio callback!");
 		return -EIO;
 	}
 
-	gpio_pin_interrupt_configure(data->gpio, data->gpio_pin,
-				     GPIO_INT_EDGE_TO_ACTIVE);
+#define INTERRUPT_MODE_WORKAROUND 1
+#if (0 == INTERRUPT_MODE_WORKAROUND)
+	/*
+	 * This appears to work; however, the failing-edge/interrupt could be missed
+	 */
+	gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+#elif (1 == INTERRUPT_MODE_WORKAROUND)
+	/*
+	 * This appears to work; however, an edge/interrupt could be missed and the ISR is called
+	 * ~2x more than should be necessary
+	 */
+	gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_EDGE_BOTH);
+#else
+	/*
+	 * This should work, but doesn't. TODO: determine cause
+	 */
+	gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_LEVEL_ACTIVE);
+#endif
 
-	if (gpio_pin_get(data->gpio, data->gpio_pin) > 0) {
+	if (gpio_pin_get_dt(&config->int_gpio) > 0) {
 		tsl2540_handle_cb(data);
 	}
 

--- a/include/zephyr/drivers/sensor/tsl2540.h
+++ b/include/zephyr/drivers/sensor/tsl2540.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 T-Mobile USA, Inc.
+ * Copyright (c) 2023 T-Mobile USA, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,11 +22,13 @@ extern "C" {
 
 enum sensor_attribute_tsl2540 {
 	/** Sensor Gain */
-	SENSOR_ATTR_GAIN = SENSOR_ATTR_PRIV_START,
+	SENSOR_ATTR_GAIN = SENSOR_ATTR_PRIV_START + 1,
 	/** Sensor Integration Time (in ms) */
 	SENSOR_ATTR_INTEGRATION_TIME,
 	/** Sensor Glass Attenuation Factor */
 	SENSOR_ATTR_GLASS_ATTENUATION,
+	/** Sensor ALS interrupt persistence filters */
+	SENSOR_ATTR_INT_APERS,
 };
 
 enum sensor_gain_tsl2540 {
@@ -36,7 +39,6 @@ enum sensor_gain_tsl2540 {
 	TSL2540_SENSOR_GAIN_64,
 	TSL2540_SENSOR_GAIN_128,
 };
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is the first pass to prepare the driver to support the TSL2540's threshold alert capability.