### PR TITLE
Draft: Add platform_exclude: efm32pg_stk3402a to all failing tests

### DIFF
--- a/samples/application_development/external_lib/sample.yaml
+++ b/samples/application_development/external_lib/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: External Library
 tests:
   sample.app_dev.external_lib:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: external

--- a/samples/application_development/out_of_tree_driver/sample.yaml
+++ b/samples/application_development/out_of_tree_driver/sample.yaml
@@ -3,6 +3,7 @@ sample:
   name: Out-of-tree driver
 tests:
   sample.drivers.out_of_tree:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: out_of_tree

--- a/samples/basic/hash_map/sample.yaml
+++ b/samples/basic/hash_map/sample.yaml
@@ -20,30 +20,32 @@ common:
 tests:
   # Minimal Libc
   libraries.hash_map.minimal.separate_chaining.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.minimal.open_addressing.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   # Newlib
   libraries.hash_map.newlib.separate_chaining.djb2:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.newlib.open_addressing.djb2:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.newlib.cxx_unordered_map.djb2:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_CXX=y
@@ -51,11 +53,13 @@ tests:
       - CONFIG_MAIN_STACK_SIZE=2048
   # PicoLibc
   libraries.hash_map.picolibc.separate_chaining.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_PICOLIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.picolibc.open_addressing.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_PICOLIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y

--- a/samples/basic/sys_heap/sample.yaml
+++ b/samples/basic/sys_heap/sample.yaml
@@ -14,4 +14,5 @@ common:
       - ".*allocated 0, free ..., max allocated ..., heap size 256.*"
 tests:
   sample.basic.sys_heap:
+    platform_exclude: efm32pg_stk3402a
     tags: heap statistics dynamic_memory

--- a/samples/basic/threads/sample.yaml
+++ b/samples/basic/threads/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: Basic Thread Demo
 tests:
   sample.basic.threads:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel threads gpio
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             dt_enabled_alias_with_parent_compat("led1", "gpio-leds")

--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -12,4 +12,5 @@ common:
       - "Validation done. (.*)"
 tests:
   sample.compression.lz4:
+    platform_exclude: efm32pg_stk3402a
     tags: compression lz4

--- a/samples/cpp/cpp_synchronization/sample.yaml
+++ b/samples/cpp/cpp_synchronization/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: Syncronisation (C++)
 tests:
   sample.cpp.synchronization:
+    platform_exclude: efm32pg_stk3402a
     tags: cpp
     toolchain_exclude: issm xcc
     integration_platforms:

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -8,6 +8,7 @@ common:
   arch_exclude: xtensa
 tests:
   sample.drivers.crypto.mbedtls:
+    platform_exclude: efm32pg_stk3402a
     min_flash: 34
     harness: console
     extra_args: CONF_FILE=prj_mtls_shim.conf
@@ -22,6 +23,7 @@ tests:
         - ".*: CCM Mode"
         - ".*: GCM Mode"
   sample.drivers.crypto.mbedtls.micro:
+    platform_exclude: efm32pg_stk3402a
     tags: crypto
     harness: console
     integration_platforms:

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -15,7 +15,7 @@ common:
 tests:
   sample.drivers.watchdog:
     filter: not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD32 or SOC_SERIES_GD32VF103)
-    platform_exclude: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
+    platform_exclude: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52 efm32pg_stk3402a
   sample.drivers.watchdog.stm32_wwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")

--- a/samples/hello_world/sample.yaml
+++ b/samples/hello_world/sample.yaml
@@ -13,4 +13,5 @@ common:
       - "Hello World! (.*)"
 tests:
   sample.basic.helloworld:
+    platform_exclude: efm32pg_stk3402a
     tags: introduction

--- a/samples/kernel/condition_variables/condvar/sample.yaml
+++ b/samples/kernel/condition_variables/condvar/sample.yaml
@@ -1,5 +1,6 @@
 tests:
   sample.kernel.cond_var:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: kernel condition_variables

--- a/samples/kernel/condition_variables/simple/sample.yaml
+++ b/samples/kernel/condition_variables/simple/sample.yaml
@@ -1,5 +1,6 @@
 tests:
   sample.kernel.cond_var.simple:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: kernel condition_variables

--- a/samples/kernel/metairq_dispatch/sample.yaml
+++ b/samples/kernel/metairq_dispatch/sample.yaml
@@ -15,5 +15,6 @@ common:
 # sample is designed to demonstrate completely arbitrary CPU work.
 tests:
   sample.kernel.metairq_dispatch:
+    platform_exclude: efm32pg_stk3402a
     tags: introduction
     filter: not CONFIG_ARCH_POSIX

--- a/samples/modules/chre/sample.yaml
+++ b/samples/modules/chre/sample.yaml
@@ -6,6 +6,7 @@ tests:
   sample.modules.chre:
     tags: introduction chre
     platform_exclude: qemu_leon3
+    platform_exclude: efm32pg_stk3402a
     modules:
       - chre
     harness: console

--- a/samples/modules/nanopb/sample.yaml
+++ b/samples/modules/nanopb/sample.yaml
@@ -12,6 +12,7 @@ common:
       - "Your lucky number was 13!"
 tests:
   sample.modules.nanopb:
+    platform_exclude: efm32pg_stk3402a
     tags: samples nanopb
     integration_platforms:
       - native_posix

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -16,26 +16,35 @@ common:
       - ".*EATING.*"
 tests:
   sample.kernel.philosopher:
+    platform_exclude: efm32pg_stk3402a
     tags: introduction
   sample.kernel.philosopher.same_prio:
+    platform_exclude: efm32pg_stk3402a
     extra_args: SAME_PRIO=1
   sample.kernel.philosopher.static:
+    platform_exclude: efm32pg_stk3402a
     extra_args: STATIC_OBJS=1
   sample.kernel.philosopher.semaphores:
+    platform_exclude: efm32pg_stk3402a
     extra_args: FORKS=SEMAPHORES
   sample.kernel.philosopher.stacks:
     extra_args: FORKS=STACKS
+    platform_exclude: efm32pg_stk3402a
   sample.kernel.philosopher.fifos:
+    platform_exclude: efm32pg_stk3402a
     extra_args: FORKS=FIFOS
   sample.kernel.philosopher.lifos:
+    platform_exclude: efm32pg_stk3402a
     extra_args: FORKS=LIFOS
   sample.kernel.philosopher.preempt_only:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_NUM_PREEMPT_PRIORITIES=6
       - CONFIG_NUM_COOP_PRIORITIES=0
       - CONFIG_BT=n
       - CONFIG_NETWORKING=n
   sample.kernel.philosopher.coop_only:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_NUM_PREEMPT_PRIORITIES=0
       - CONFIG_NUM_COOP_PRIORITIES=7

--- a/samples/posix/eventfd/sample.yaml
+++ b/samples/posix/eventfd/sample.yaml
@@ -9,6 +9,7 @@ common:
     - mps2_an385
 tests:
   sample.posix.eventfd:
+    platform_exclude: efm32pg_stk3402a
     min_ram: 32
     tags: posix
     harness: console

--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: logger sample
 tests:
   sample.logger.basic:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: logging

--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -7,6 +7,7 @@ common:
   arch_exclude: mips nios2 posix sparc
 tests:
   sample.logger.syst.deferred:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
@@ -28,6 +29,7 @@ tests:
     # Not all compillers announced in Zephyr support NewLib.
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.immediate:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_immediate.conf
     integration_platforms:
@@ -43,6 +45,7 @@ tests:
         - "SYST Sample Execution Completed"
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.deferred:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
     integration_platforms:
@@ -59,6 +62,7 @@ tests:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.immediate:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
@@ -74,6 +78,7 @@ tests:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.deferred_cpp:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
     integration_platforms:
@@ -91,6 +96,7 @@ tests:
       - CONFIG_CPP=y
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.immediate_cpp:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
@@ -107,6 +113,7 @@ tests:
       - CONFIG_CPP=y
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.deferred_cpp:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
     integration_platforms:
@@ -124,6 +131,7 @@ tests:
       - CONFIG_CPP=y
     filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.immediate_cpp:
+    platform_exclude: efm32pg_stk3402a
     toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385

--- a/samples/subsys/nvs/sample.yaml
+++ b/samples/subsys/nvs/sample.yaml
@@ -6,6 +6,7 @@ tests:
     tags: settings
     depends_on: nvs
     platform_exclude: qemu_x86
+    platform_exclude: efm32pg_stk3402a
     harness: console
     harness_config:
       type: multi_line

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -19,8 +19,11 @@ common:
       - ".*THINKING.*"
 tests:
   sample.portability.cmsis_rtos_v1.philosopher:
+    platform_exclude: efm32pg_stk3402a
     tags: cmsis_rtos
   sample.portability.cmsis_rtos_v1.philosopher.same_prio:
+    platform_exclude: efm32pg_stk3402a
     extra_args: SAME_PRIO=1
   sample.portability.cmsis_rtos_v1.philosopher.semaphores:
+    platform_exclude: efm32pg_stk3402a
     extra_args: FORKS=SEMAPHORES

--- a/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: CMSIS_RTOS_V1 Synchronization
 tests:
   sample.portability.cmsis_rtos_v1.timer_synchronization:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: cmsis_rtos

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.yaml
@@ -19,8 +19,11 @@ common:
       - ".*EATING.*"
 tests:
   sample.portability.cmsis_rtos_v2.philosopher:
+    platform_exclude: efm32pg_stk3402a
     tags: cmsis_rtos
   sample.portability.cmsis_rtos_v2.philosopher.same_prio:
+    platform_exclude: efm32pg_stk3402a
     extra_args: SAME_PRIO=1
   sample.portability.cmsis_rtos_v2.philosopher.semaphores:
+    platform_exclude: efm32pg_stk3402a
     extra_args: FORKS=SEMAPHORES

--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: CMSIS_RTOS_V2 Synchronization
 tests:
   sample.portability.cmsis_rtos_v2.timer_synchronization:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: cmsis_rtos

--- a/samples/subsys/rtio/sensor_batch_processing/sample.yaml
+++ b/samples/subsys/rtio/sensor_batch_processing/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: RTIO sample
 tests:
   sample.rtio.sensor_batch_processing:
+    platform_exclude: efm32pg_stk3402a
     tags: rtio
     integration_platforms:
       - native_posix

--- a/samples/subsys/task_wdt/sample.yaml
+++ b/samples/subsys/task_wdt/sample.yaml
@@ -18,4 +18,4 @@ tests:
     depends_on: watchdog
     integration_platforms:
       - nucleo_g474re
-    platform_exclude: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
+    platform_exclude: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52 efm32pg_stk3402a

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -8,6 +8,7 @@ common:
       - "thread_b: Hello World from (.*)!"
 tests:
   sample.tracing.user:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE="prj_user.conf"
   sample.tracing.format.sysview:
     platform_allow: nrf52840dk_nrf52840 mimxrt1050_evk mimxrt1064_evk
@@ -16,7 +17,7 @@ tests:
     extra_args: CONF_FILE="prj_sysview.conf"
   sample.tracing.osawareness.openocd:
     arch_exclude: posix xtensa
-    platform_exclude: qemu_x86_64
+    platform_exclude: qemu_x86_64 efm32pg_stk3402a
   sample.tracing.transport.uart:
     platform_allow: qemu_x86 qemu_x86_64
     integration_platforms:

--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -21,7 +21,7 @@ tests:
       - CONFIG_BM_ASYNC=y
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
-    platform_exclude: nrf52_bsim
+    platform_exclude: nrf52_bsim efm32pg_stk3402a
   sample.zbus.benchmark_sync:
     tags: zbus
     min_ram: 16
@@ -42,4 +42,4 @@ tests:
       - CONFIG_BM_ASYNC=n
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
-    platform_exclude: nrf52_bsim
+    platform_exclude: nrf52_bsim efm32pg_stk3402a

--- a/samples/subsys/zbus/dyn_channel/sample.yaml
+++ b/samples/subsys/zbus/dyn_channel/sample.yaml
@@ -65,4 +65,5 @@ common:
       - "W: 0f 0f 0f 0f 0f 0f 0f 0f |........"
 tests:
   sample.zbus.dyn_channel:
+    platform_exclude: efm32pg_stk3402a
     tags: zbus

--- a/samples/subsys/zbus/hello_world/sample.yaml
+++ b/samples/subsys/zbus/hello_world/sample.yaml
@@ -27,7 +27,7 @@ tests:
         - "I: Pub a valid value to a channel with validator successfully."
         - "I: Pub an invalid value to a channel with validator successfully."
     arch_exclude: posix xtensa
-    platform_exclude: qemu_leon3
+    platform_exclude: qemu_leon3 efm32pg_stk3402a
     tags: zbus
   sample.zbus.hello_world_no_iterable_sections:
     harness: console

--- a/samples/subsys/zbus/runtime_obs_registration/sample.yaml
+++ b/samples/subsys/zbus/runtime_obs_registration/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: Runtime observer registration
 tests:
   sample.zbus.runtime_os_registration:
+    platform_exclude: efm32pg_stk3402a
     min_ram: 16
     harness: console
     harness_config:

--- a/samples/subsys/zbus/work_queue/sample.yaml
+++ b/samples/subsys/zbus/work_queue/sample.yaml
@@ -28,4 +28,5 @@ common:
 
 tests:
   sample.zbus.work_queue:
+    platform_exclude: efm32pg_stk3402a
     tags: zbus

--- a/samples/synchronization/sample.yaml
+++ b/samples/synchronization/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: Synchronization Sample
 tests:
   sample.kernel.synchronization:
+    platform_exclude: efm32pg_stk3402a
     build_on_all: true
     tags: synchronization
     harness: console

--- a/samples/userspace/hello_world_user/sample.yaml
+++ b/samples/userspace/hello_world_user/sample.yaml
@@ -14,5 +14,6 @@ common:
       - "Hello World from UserSpace! (.*)"
 tests:
   sample.helloworld:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: introduction

--- a/samples/userspace/prod_consumer/sample.yaml
+++ b/samples/userspace/prod_consumer/sample.yaml
@@ -12,4 +12,5 @@ common:
       - "SUCCESS"
 tests:
   sample.userspace.prod_consumer:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_USERSPACE

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -14,6 +14,6 @@ common:
 tests:
   sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    platform_exclude: twr_ke18f
+    platform_exclude: twr_ke18f efm32pg_stk3402a
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/application_development/gen_inc_file/testcase.yaml
+++ b/tests/application_development/gen_inc_file/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   buildsystem.include_file:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     tags: gen_inc_file

--- a/tests/arch/arm/arm_hardfault_validation/testcase.yaml
+++ b/tests/arch/arm/arm_hardfault_validation/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   arch.interrupt.arm.hardfault_validation:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ARMV7_M_ARMV8_M_MAINLINE
     arch_allow: arm
     tags: arm

--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -5,14 +5,17 @@ common:
   arch_allow: arm
 tests:
   arch.interrupt.arm:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.interrupt.no_optimizations:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
       - CONFIG_MAIN_STACK_SIZE=2048
   arch.interrupt.extra_exception_info:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_EXTRA_EXCEPTION_INFO=y

--- a/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
+++ b/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
@@ -4,6 +4,7 @@ common:
   arch_allow: arm
 tests:
   arch.arm.irq_advanced_features:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.arm.irq_advanced_features.secure_fw:
     filter: CONFIG_TRUSTED_EXECUTION_SECURE

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -4,4 +4,5 @@ common:
   arch_allow: arm
 tests:
   arch.arm.irq_vector_table:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE

--- a/tests/arch/arm/arm_irq_zero_latency_levels/testcase.yaml
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/testcase.yaml
@@ -5,6 +5,7 @@ common:
   arch_allow: arm
 tests:
   arch.arm.irq_zero_latency_levels:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.arm.irq_zero_latency_levels.secure_fw:
     filter: CONFIG_TRUSTED_EXECUTION_SECURE

--- a/tests/arch/arm/arm_ramfunc/testcase.yaml
+++ b/tests/arch/arm/arm_ramfunc/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   arch.arm.ramfunc:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
     tags: arm userspace
     arch_allow: arm

--- a/tests/arch/arm/arm_runtime_nmi/testcase.yaml
+++ b/tests/arch/arm/arm_runtime_nmi/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   arch.interrupt.arm.nmi:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE and
       not CONFIG_BUILD_WITH_TFM
     arch_allow: arm

--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -4,8 +4,10 @@ common:
   arch_allow: arm
 tests:
   arch.arm.swap.common:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.arm.swap.common.no_optimizations:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
@@ -13,11 +15,13 @@ tests:
       - CONFIG_MAIN_STACK_SIZE=2048
     min_flash: 192
   arch.arm.swap.common.fpu_sharing:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ARMV7_M_ARMV8_M_FP
     extra_configs:
       - CONFIG_FPU=y
       - CONFIG_FPU_SHARING=y
   arch.arm.swap.common.fpu_sharing.no_optimizations:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ARMV7_M_ARMV8_M_FP
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/arch/arm/arm_tz_wrap_func/testcase.yaml
+++ b/tests/arch/arm/arm_tz_wrap_func/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   arch.arm.tz_wrap_func:
+    platform_exclude: efm32pg_stk3402a
     arch_allow: arm
     tags: arm tz_ns tz_wrap_func
     filter: CONFIG_CPU_CORTEX_M

--- a/tests/arch/common/timing/testcase.yaml
+++ b/tests/arch/common/timing/testcase.yaml
@@ -5,4 +5,5 @@ common:
     - native
 tests:
   arch.common.timing:
+    platform_exclude: efm32pg_stk3402a
     tags: timing arch

--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -3,6 +3,7 @@ common:
   timeout: 420
 tests:
   benchmark.kernel.application:
+    platform_exclude: efm32pg_stk3402a
     min_flash: 34
   benchmark.kernel.application.fp:
     extra_args: CONF_FILE=prj_fp.conf

--- a/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   benchmark.cmsis_dsp.basicmath:
+    platform_exclude: efm32pg_stk3402a
     filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
@@ -9,6 +10,7 @@ tests:
     min_flash: 128
     min_ram: 64
   benchmark.cmsis_dsp.basicmath.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:

--- a/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   benchmark.data_structure_perf.dlist:
+    platform_exclude: efm32pg_stk3402a
     tags: benchmark dlist

--- a/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   benchmark.data_structure_perf.rbtree:
+    platform_exclude: efm32pg_stk3402a
     tags: benchmark rbtree

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   benchmark.kernel.latency:
     # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
-    platform_exclude: qemu_cortex_m0 m2gl025_miv
+    platform_exclude: qemu_cortex_m0 m2gl025_miv efm32pg_stk3402a
     filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
     tags: benchmark
     harness: console

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   benchmark.kernel.core:
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: nios2 xtensa
     min_ram: 32
     tags: benchmark

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -5,7 +5,7 @@ common:
   timeout: 400
 tests:
   crypto.mbedtls:
-    platform_exclude: m2gl025_miv
+    platform_exclude: m2gl025_miv efm32pg_stk3402a
     extra_configs:
       - CONFIG_PICOLIBC_HEAP_SIZE=0
       - arch:riscv64:CONFIG_ZTEST_STACK_SIZE=8192

--- a/tests/drivers/console/testcase.yaml
+++ b/tests/drivers/console/testcase.yaml
@@ -8,6 +8,7 @@ common:
 
 tests:
   drivers.console.uart:
+    platform_exclude: efm32pg_stk3402a
     tags: drivers console uart
     filter: CONFIG_UART_CONSOLE
   drivers.console.semihost:

--- a/tests/drivers/coredump/coredump_api/testcase.yaml
+++ b/tests/drivers/coredump/coredump_api/testcase.yaml
@@ -31,7 +31,7 @@ tests:
         - "E: #CD:END#"
   drivers.coredump.api:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
-    platform_exclude: qemu_riscv32
+    platform_exclude: qemu_riscv32 efm32pg_stk3402a
     harness: console
     harness_config:
       type: multi_line

--- a/tests/drivers/eeprom/shell/testcase.yaml
+++ b/tests/drivers/eeprom/shell/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   drivers.eeprom.shell:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
       - native_posix_64

--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   drivers.entropy:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ENTROPY_HAS_DRIVER
     tags: drivers entropy
   drivers.entropy.bt_hci:

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -27,6 +27,7 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
   drivers.flash.default:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and
         not CONFIG_TRUSTED_EXECUTION_NONSECURE) and
         dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))

--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     depends_on: gpio
     min_flash: 48
     # Fix exclude when we can exclude just sim run
-    platform_exclude: mps2_an385 mps2_an521 neorv32
+    platform_exclude: mps2_an385 mps2_an521 neorv32 efm32pg_stk3402a
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")

--- a/tests/drivers/gpio/gpio_get_direction/testcase.yaml
+++ b/tests/drivers/gpio/gpio_get_direction/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     depends_on: gpio
     min_flash: 48
     # Fix exclude when we can exclude just sim run
-    platform_exclude: mps2_an385 mps2_an521 neorv32
+    platform_exclude: mps2_an385 mps2_an521 neorv32 efm32pg_stk3402a
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")

--- a/tests/drivers/hwinfo/api/testcase.yaml
+++ b/tests/drivers/hwinfo/api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   drivers.hwinfo.api:
+    platform_exclude: efm32pg_stk3402a
     tags: drivers hwinfo

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   drivers.ipc.mailbox:
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: posix xtensa
     tags: drivers ipc

--- a/tests/drivers/mm/sys_mm_drv_api/testcase.yaml
+++ b/tests/drivers/mm/sys_mm_drv_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   drivers.mm.sys_mm_drv_api:
+    platform_exclude: efm32pg_stk3402a
     tags: drivers mm

--- a/tests/drivers/sensor/generic/testcase.yaml
+++ b/tests/drivers/sensor/generic/testcase.yaml
@@ -4,7 +4,9 @@ common:
     - mps2_an385
 tests:
   drivers.sensor.generic:
+    platform_exclude: efm32pg_stk3402a
     tags: drivers sensor
   drivers.sensor.generic.fpu:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_fpu.conf
     tags: drivers sensor

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -8,7 +8,7 @@ tests:
        or dt_compat_enabled("st,stm32-watchdog") or CONFIG_SOC_FAMILY_LPC or
        CONFIG_SOC_SERIES_IMX_RT6XX or CONFIG_SOC_SERIES_IMX_RT5XX or
        CONFIG_SOC_FAMILY_GD32 or SOC_SERIES_GD32VF103)
-    platform_exclude: mec15xxevb_assy6853 s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
+    platform_exclude: mec15xxevb_assy6853 s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52 efm32pg_stk3402a
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -6,6 +6,7 @@ tests:
   kernel.common:
     build_on_all: true
   kernel.common.tls:
+    platform_exclude: efm32pg_stk3402a
     # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
     filter: >
       CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
@@ -14,22 +15,26 @@ tests:
       - CONFIG_THREAD_LOCAL_STORAGE=y
   kernel.common.misra:
     # Some configurations are known-incompliant and won't build
+    platform_exclude: efm32pg_stk3402a
     filter: not ((CONFIG_I2C or CONFIG_SPI) and CONFIG_USERSPACE)
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_MISRA_SANE=y
   kernel.common.nano32:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_KERNEL_COHERENCE
     extra_configs:
       - CONFIG_CBPRINTF_NANO=y
       - CONFIG_CBPRINTF_REDUCED_INTEGRAL=y
   kernel.common.nano64:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_KERNEL_COHERENCE
     extra_configs:
       - CONFIG_CBPRINTF_NANO=y
       - CONFIG_CBPRINTF_FULL_INTEGRAL=y
   kernel.common.picolibc:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -5,7 +5,7 @@ common:
 tests:
   kernel.device:
     tags: kernel device
-    platform_exclude: beaglev_starlight_jh7100
+    platform_exclude: beaglev_starlight_jh7100 efm32pg_stk3402a
   kernel.device.pm:
     tags: kernel device
     platform_exclude: mec15xxevb_assy6853 beaglev_starlight_jh7100

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.common.sleep:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel sleep
   kernel.common.sleep.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/fifo/fifo_api/testcase.yaml
+++ b/tests/kernel/fifo/fifo_api/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.fifo:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel
   kernel.fifo.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/fifo/fifo_timeout/testcase.yaml
+++ b/tests/kernel/fifo/fifo_timeout/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.fifo.timeout:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel
   kernel.fifo.timeout.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/fifo/fifo_usage/testcase.yaml
+++ b/tests/kernel/fifo/fifo_usage/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.fifo.usage:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel fifo
   kernel.fifo.usage.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/mbox/mbox_usage/testcase.yaml
+++ b/tests/kernel/mbox/mbox_usage/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.mailbox.usage:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel mailbox
   kernel.mailbox.usage.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.memory_heap:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel memory_heap
     extra_configs:
       - CONFIG_IRQ_OFFLOAD=y

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -4,7 +4,7 @@ common:
 tests:
   kernel.memory_protection:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    platform_exclude: twr_ke18f
+    platform_exclude: twr_ke18f efm32pg_stk3402a
     extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n CONFIG_MINIMAL_LIBC=y
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS

--- a/tests/kernel/mem_protect/stack_random/testcase.yaml
+++ b/tests/kernel/mem_protect/stack_random/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.memory_protection.stack_random:
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: posix
     tags: kernel memory_protection

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.memory_protection.stackprot:
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: nios2 xtensa posix sparc
     tags: kernel userspace
     ignore_faults: true

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags: kernel security userspace
 tests:
   kernel.memory_protection.userspace:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/kernel/obj_tracking/testcase.yaml
+++ b/tests/kernel/obj_tracking/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.objects.tracking:
     tags: kernel
-    platform_exclude: qemu_x86_tiny
+    platform_exclude: qemu_x86_tiny efm32pg_stk3402a

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.objects:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel

--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -3,4 +3,4 @@ tests:
     ignore_faults: true
     tags: kernel userspace
     # FIXME: qemu_arc_hs6x is excluded due to a run-time failure, see #49492
-    platform_exclude: nrf52dk_nrf52810 qemu_arc_hs6x
+    platform_exclude: nrf52dk_nrf52810 qemu_arc_hs6x efm32pg_stk3402a

--- a/tests/kernel/sched/metairq/testcase.yaml
+++ b/tests/kernel/sched/metairq/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   kernel.scheduler.metairq:
     tags: kernel
-    platform_exclude: nrf52dk_nrf52810
+    platform_exclude: nrf52dk_nrf52810 efm32pg_stk3402a
   kernel.scheduler.metairq.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: linker_generator

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=n
   kernel.scheduler.slice_perthread:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=y
@@ -26,10 +27,12 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=n
   kernel.scheduler.dumb_timeslicing:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_dumb.conf
     extra_configs:
       - CONFIG_TIMESLICING=y
   kernel.scheduler.dumb_no_timeslicing:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_dumb.conf
     extra_configs:
       - CONFIG_TIMESLICING=n

--- a/tests/kernel/threads/dynamic_thread/testcase.yaml
+++ b/tests/kernel/threads/dynamic_thread/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.threads.dynamic:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel threads userspace
     ignore_faults: true
     filter: CONFIG_ARCH_HAS_USERSPACE

--- a/tests/kernel/threads/thread_error_case/testcase.yaml
+++ b/tests/kernel/threads/thread_error_case/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.threads.error.case:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel threads userspace
     filter: CONFIG_USERSPACE
     ignore_faults: true

--- a/tests/kernel/threads/thread_stack/testcase.yaml
+++ b/tests/kernel/threads/thread_stack/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.threads.thread_stack:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel security userspace
     ignore_faults: true
     min_ram: 16

--- a/tests/kernel/threads/tls/testcase.yaml
+++ b/tests/kernel/threads/tls/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.threads.tls:
+    platform_exclude: efm32pg_stk3402a
     tags: kernel threads
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
   kernel.threads.tls.userspace:

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     # FIXME: This test fails sporadically on all QEMU platforms, but fails
     # consistently when coverage is enabled. Disable until 14173 is fixed.
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
-      nrf5340dk_nrf5340_cpunet nucleo_l073rz
+      nrf5340dk_nrf5340_cpunet nucleo_l073rz efm32pg_stk3402a
     tags: kernel

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -5,7 +5,7 @@ tests:
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: nios2 posix
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
-      nrf5340dk_nrf5340_cpunet
+      nrf5340dk_nrf5340_cpunet efm32pg_stk3402a
     tags: kernel timer userspace
   kernel.timer.no_multitheading:
     tags: kernel timer

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     tags: kernel timer
     # FIXME: This test may fail for qemu_arc_hs on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#67.
-    platform_exclude: qemu_arc_hs
+    platform_exclude: qemu_arc_hs efm32pg_stk3402a
   kernel.timer.monotonic.apic.tsc:
     tags: kernel timer apic_tsc
     platform_allow: ehl_crb

--- a/tests/kernel/workq/work_queue/testcase.yaml
+++ b/tests/kernel/workq/work_queue/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.workqueue:
+    platform_exclude: efm32pg_stk3402a
     min_flash: 34
     tags: kernel
   kernel.workqueue.linker_generator:

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -3,18 +3,22 @@ common:
   platform_exclude: native_posix native_posix_64 nrf52_bsim
 tests:
   libraries.libc:
+    platform_exclude: efm32pg_stk3402a
     ignore_faults: true
   libraries.libc.picolibc:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     ignore_faults: true
     extra_configs:
       - CONFIG_PICOLIBC=y
   libraries.libc.minimal.strerror_table:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_MINIMAL_LIBC_STRING_ERROR_TABLE=y
   libraries.libc.minimal.no_strerror_table:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_MINIMAL_LIBC_STRING_ERROR_TABLE=n

--- a/tests/lib/cbprintf_fp/testcase.yaml
+++ b/tests/lib/cbprintf_fp/testcase.yaml
@@ -8,6 +8,7 @@ common:
   filter: CONFIG_CONSOLE_HAS_DRIVER
 tests:
   libraries.cbprintf_fp.printk:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTK=y
     harness_config:
@@ -17,6 +18,7 @@ tests:
         - "Hello with printk"
         - "Complete"
   libraries.cbprintf_fp.printf:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTF=y
     harness_config:
@@ -26,6 +28,7 @@ tests:
         - "Hello with printf"
         - "Complete"
   libraries.cbprintf_fp.printf_nl:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTF=y
@@ -37,6 +40,7 @@ tests:
         - "Hello with printf/newlib"
         - "Complete"
   libraries.cbprintf_fp.printfcb:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTFCB=y
     harness_config:
@@ -46,6 +50,7 @@ tests:
         - "Hello with printfcb"
         - "Complete"
   libraries.cbprintf_fp.printfcb_nl:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_APP_FORMATTER_PRINTFCB=y
@@ -57,6 +62,7 @@ tests:
         - "Hello with printfcb/newlib"
         - "Complete"
   libraries.cbprintf_fp.fprintf:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_APP_FORMATTER_FPRINTF=y
     harness_config:
@@ -66,6 +72,7 @@ tests:
         - "Hello with fprintf"
         - "Complete"
   libraries.cbprintf_fp.fprintfcb:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_APP_FORMATTER_FPRINTFCB=y
     harness_config:
@@ -75,6 +82,7 @@ tests:
         - "Hello with fprintfcb"
         - "Complete"
   libraries.cbprintf_fp.printf.picolibc:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:
@@ -87,6 +95,7 @@ tests:
         - "Hello with printf"
         - "Complete"
   libraries.cbprintf_fp.printfcb.picolibc:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:

--- a/tests/lib/cmsis_dsp/bayes/testcase.yaml
+++ b/tests/lib/cmsis_dsp/bayes/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.bayes:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 64
     min_ram: 32
   libraries.cmsis_dsp.bayes.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/complexmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/complexmath/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.complexmath:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 144
   libraries.cmsis_dsp.complexmath.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and
       CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/distance/testcase.yaml
+++ b/tests/lib/cmsis_dsp/distance/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.distance:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 64
     min_ram: 32
   libraries.cmsis_dsp.distance.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/fastmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/fastmath/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.fastmath:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 64
   libraries.cmsis_dsp.fastmath.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/filtering/testcase.yaml
+++ b/tests/lib/cmsis_dsp/filtering/testcase.yaml
@@ -8,6 +8,7 @@ tests:
     tags: cmsis_dsp
     skip: true
   libraries.cmsis_dsp.filtering.biquad:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -22,6 +23,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_BIQUAD=y
   libraries.cmsis_dsp.filtering.biquad.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -35,6 +37,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_BIQUAD=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.filtering.decim:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -49,6 +52,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_DECIM=y
   libraries.cmsis_dsp.filtering.decim.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -62,6 +66,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_DECIM=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.filtering.fir:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -76,6 +81,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_FIR=y
   libraries.cmsis_dsp.filtering.fir.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -89,6 +95,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_FIR=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.filtering.misc:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -103,6 +110,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_FILTERING_MISC=y
   libraries.cmsis_dsp.filtering.misc.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/interpolation/testcase.yaml
+++ b/tests/lib/cmsis_dsp/interpolation/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.interpolation:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 64
   libraries.cmsis_dsp.interpolation.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and
       CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -5,6 +5,7 @@ tests:
     tags: cmsis_dsp
     skip: true
   libraries.cmsis_dsp.matrix.unary_q7:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -19,6 +20,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q7=y
   libraries.cmsis_dsp.matrix.unary_q7.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -32,6 +34,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q7=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_q15:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -46,6 +49,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q15=y
   libraries.cmsis_dsp.matrix.unary_q15.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -59,6 +63,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q15=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_q31:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -73,6 +78,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q31=y
   libraries.cmsis_dsp.matrix.unary_q31.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -112,6 +118,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F16=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_f32:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -126,6 +133,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F32=y
   libraries.cmsis_dsp.matrix.unary_f32.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -139,6 +147,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F32=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_f64:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -153,6 +162,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y
   libraries.cmsis_dsp.matrix.unary_f64.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -174,7 +184,7 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -187,7 +197,7 @@ tests:
       - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -203,7 +213,7 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 144
     extra_args: CONF_FILE=prj_base.conf
@@ -216,7 +226,7 @@ tests:
       - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 144
     extra_args: CONF_FILE=prj_base.conf
@@ -232,7 +242,7 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -245,7 +255,7 @@ tests:
       - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -287,7 +297,7 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -300,7 +310,7 @@ tests:
       - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -316,7 +326,7 @@ tests:
       - mps2_an521
       - native_posix
     tags: cmsis_dsp
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
@@ -329,7 +339,7 @@ tests:
       - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
-    platform_exclude: frdm_kw41z
+    platform_exclude: frdm_kw41z efm32pg_stk3402a
     min_flash: 128
     min_ram: 128
     extra_args: CONF_FILE=prj_base.conf

--- a/tests/lib/cmsis_dsp/quaternionmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/quaternionmath/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.quaternionmath:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 64
   libraries.cmsis_dsp.quaternionmath.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and
       CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/statistics/testcase.yaml
+++ b/tests/lib/cmsis_dsp/statistics/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.statistics:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 64
   libraries.cmsis_dsp.statistics.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and
       CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/support/testcase.yaml
+++ b/tests/lib/cmsis_dsp/support/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.support:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 128
   libraries.cmsis_dsp.support.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/svm/testcase.yaml
+++ b/tests/lib/cmsis_dsp/svm/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_dsp.svm:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -11,6 +12,7 @@ tests:
     min_flash: 128
     min_ram: 64
   libraries.cmsis_dsp.svm.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -5,6 +5,7 @@ tests:
     tags: cmsis_dsp
     skip: true
   libraries.cmsis_dsp.transform.cq15:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -19,6 +20,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ15=y
   libraries.cmsis_dsp.transform.cq15.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -31,6 +33,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ15=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rq15:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -45,6 +48,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ15=y
   libraries.cmsis_dsp.transform.rq15.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -57,6 +61,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ15=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cq31:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -71,6 +76,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
   libraries.cmsis_dsp.transform.cq31.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     tags: cmsis_dsp fpu
@@ -81,6 +87,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rq31:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -95,6 +102,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ31=y
   libraries.cmsis_dsp.transform.rq31.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     tags: cmsis_dsp fpu
@@ -155,6 +163,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF16=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cf32:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -169,6 +178,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF32=y
   libraries.cmsis_dsp.transform.cf32.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     tags: cmsis_dsp fpu
@@ -179,6 +189,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF32=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rf32:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -193,6 +204,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF32=y
   libraries.cmsis_dsp.transform.rf32.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -205,6 +217,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF32=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cf64:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -219,6 +232,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y
   libraries.cmsis_dsp.transform.cf64.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     tags: cmsis_dsp fpu
@@ -229,6 +243,7 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rf64:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or
       CONFIG_ARCH_POSIX
     integration_platforms:
@@ -243,6 +258,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF64=y
   libraries.cmsis_dsp.transform.rf64.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and
       TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     tags: cmsis_dsp fpu

--- a/tests/lib/cmsis_nn/testcase.yaml
+++ b/tests/lib/cmsis_nn/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.cmsis_nn:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_CPU_CORTEX_M and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f

--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -7,14 +7,17 @@ common:
 
 tests:
   cpp.main.minimal:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
   cpp.main.newlib:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     min_ram: 32
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   cpp.main.newlib_nano:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_HAS_NEWLIB_LIBC_NANO
     min_ram: 24
     extra_configs:

--- a/tests/lib/devicetree/api_ext/testcase.yaml
+++ b/tests/lib/devicetree/api_ext/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.devicetree.api_ext:
+    platform_exclude: efm32pg_stk3402a
     tags: devicetree
     # We only need this to run on one platform so use native_posix as it
     # will mostly likely be the fastest.

--- a/tests/lib/devicetree/devices/testcase.yaml
+++ b/tests/lib/devicetree/devices/testcase.yaml
@@ -7,3 +7,4 @@ tests:
       - native_posix
     platform_exclude: hsdk hsdk_2cores thingy52_nrf52832 bbc_microbit bbc_microbit_v2 bt610
        bl5340_dvk_cpuapp bl5340_dvk_cpuapp_ns mimxrt595_evk_cm33
+       efm32pg_stk3402a

--- a/tests/lib/fdtable/testcase.yaml
+++ b/tests/lib/fdtable/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.os.fdtable:
+    platform_exclude: efm32pg_stk3402a
     tags: fdtable
     integration_platforms:
       - qemu_x86

--- a/tests/lib/hash_function/testcase.yaml
+++ b/tests/lib/hash_function/testcase.yaml
@@ -8,10 +8,11 @@ common:
 tests:
   libraries.hash_function.identity:
     # RNG seems to be broken on qemu_cortex_a53
-    platform_exclude: qemu_cortex_a53
+    platform_exclude: qemu_cortex_a53 efm32pg_stk3402a
     extra_configs:
       - CONFIG_SYS_HASH_FUNC32_CHOICE_IDENTITY=y
   libraries.hash_function.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_SYS_HASH_FUNC32_DJB2=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y

--- a/tests/lib/hash_map/testcase.yaml
+++ b/tests/lib/hash_map/testcase.yaml
@@ -9,14 +9,17 @@ common:
 
 tests:
   libraries.hash_map.separate_chaining.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.open_addressing.djb2:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.cxx.djb2:
+    platform_exclude: efm32pg_stk3402a
     # need newlib for the c++ runtime
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:

--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -9,5 +9,6 @@ tests:
   libraries.heap:
     tags: heap
     platform_exclude: m2gl025_miv qemu_xtensa esp32s2_saola esp32s3_devkitm
+      efm32pg_stk3402a
     filter: not CONFIG_SOC_NSIM
     timeout: 480

--- a/tests/lib/heap_align/testcase.yaml
+++ b/tests/lib/heap_align/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.heap_align:
+    platform_exclude: efm32pg_stk3402a
     tags: heap heap_align

--- a/tests/lib/json/testcase.yaml
+++ b/tests/lib/json/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.encoding.json:
+    platform_exclude: efm32pg_stk3402a
     filter: not CONFIG_NEWLIB_LIBC
     min_flash: 34
     tags: json

--- a/tests/lib/linear_range/testcase.yaml
+++ b/tests/lib/linear_range/testcase.yaml
@@ -3,5 +3,6 @@
 
 tests:
   libraries.linear_range:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix

--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -3,24 +3,25 @@ common:
 tests:
   libraries.libc.minimal.mem_alloc:
     extra_args: CONF_FILE=prj.conf
-    platform_exclude: twr_ke18f
+    platform_exclude: twr_ke18f efm32pg_stk3402a
     tags: clib minimal_libc userspace
   libraries.libc.minimal.mem_alloc_negative_testing:
     extra_args: CONF_FILE=prj_negative_testing.conf
-    platform_exclude: twr_ke18f
+    platform_exclude: twr_ke18f efm32pg_stk3402a
     tags: clib minimal_libc userspace
   libraries.libc.newlib.mem_alloc:
     extra_args: CONF_FILE=prj_newlib.conf
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     min_ram: 16
-    platform_exclude: twr_ke18f native_posix_64 nrf52_bsim
+    platform_exclude: twr_ke18f native_posix_64 nrf52_bsim efm32pg_stk3402a
     tags: clib newlib userspace
   libraries.libc.newlib_nano.mem_alloc:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_newlibnano.conf
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
     tags: clib newlib userspace
   libraries.libc.picolibc.mem_alloc:
     extra_args: CONF_FILE=prj_picolibc.conf
     filter: CONFIG_PICOLIBC_SUPPORTED
-    platform_exclude: twr_ke18f native_posix_64 nrf52_bsim
+    platform_exclude: twr_ke18f native_posix_64 nrf52_bsim efm32pg_stk3402a
     tags: clib picolibc userspace

--- a/tests/lib/mem_blocks/testcase.yaml
+++ b/tests/lib/mem_blocks/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.mem_blocks:
+    platform_exclude: efm32pg_stk3402a
     tags: heap mem_blocks

--- a/tests/lib/mem_blocks_stats/testcase.yaml
+++ b/tests/lib/mem_blocks_stats/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.mem_blocks.stats:
+    platform_exclude: efm32pg_stk3402a
     tags: heap mem_blocks.stats

--- a/tests/lib/newlib/heap_listener/testcase.yaml
+++ b/tests/lib/newlib/heap_listener/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   libraries.libc.newlib.heap_listener:
+    platform_exclude: efm32pg_stk3402a
     tags: clib newlib
     filter: TOOLCHAIN_HAS_NEWLIB == 1

--- a/tests/lib/newlib/thread_safety/testcase.yaml
+++ b/tests/lib/newlib/thread_safety/testcase.yaml
@@ -2,6 +2,7 @@ common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   libraries.libc.newlib.thread_safety:
+    platform_exclude: efm32pg_stk3402a
     tags: clib newlib
     min_ram: 64
     testcases:
@@ -28,6 +29,7 @@ tests:
     - sinit_lock
     - tz_lock
   libraries.libc.newlib.thread_safety.userspace:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_userspace.conf
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: clib newlib userspace
@@ -41,6 +43,7 @@ tests:
     - sinit_lock
     - tz_lock
   libraries.libc.newlib.thread_safety.userspace.stress:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_userspace.conf
     extra_configs:
     - CONFIG_NEWLIB_THREAD_SAFETY_TEST_STRESS=y
@@ -60,6 +63,7 @@ tests:
     - tz_lock
     timeout: 120
   libraries.libc.newlib_nano.thread_safety:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
     - CONFIG_NEWLIB_LIBC_NANO=y
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
@@ -91,6 +95,7 @@ tests:
     - sinit_lock
     - tz_lock
   libraries.libc.newlib_nano.thread_safety.userspace:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_userspace.conf
     extra_configs:
     - CONFIG_NEWLIB_LIBC_NANO=y

--- a/tests/lib/notify/testcase.yaml
+++ b/tests/lib/notify/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.data_structures:
+    platform_exclude: efm32pg_stk3402a
     tags: notify
     integration_platforms:
       - native_posix

--- a/tests/lib/onoff/testcase.yaml
+++ b/tests/lib/onoff/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.onoff:
+    platform_exclude: efm32pg_stk3402a
     tags: onoff timer
     integration_platforms:
       - native_posix

--- a/tests/lib/p4workq/testcase.yaml
+++ b/tests/lib/p4workq/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.p4wq:
+    platform_exclude: efm32pg_stk3402a
     tags: p4wq

--- a/tests/lib/ringbuffer/testcase.yaml
+++ b/tests/lib/ringbuffer/testcase.yaml
@@ -4,6 +4,7 @@ common:
 
 tests:
   libraries.ring_buffer:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
       - native_posix_64

--- a/tests/lib/smf/testcase.yaml
+++ b/tests/lib/smf/testcase.yaml
@@ -3,10 +3,12 @@ common:
     - native_posix
 tests:
   libraries.smf.flat:
+    platform_exclude: efm32pg_stk3402a
     tags: smf
     testcases:
       - smf_flat
   libraries.smf.hierarchical:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_SMF_ANCESTOR_SUPPORT=y
     tags: smf

--- a/tests/lib/sprintf/testcase.yaml
+++ b/tests/lib/sprintf/testcase.yaml
@@ -4,7 +4,7 @@ tests:
     filter: not CONFIG_SOC_MCIMX7_M4 and CONFIG_STDOUT_CONSOLE
     integration_platforms:
     - qemu_x86
-    platform_exclude: native_posix native_posix_64 nrf52_bsim
+    platform_exclude: native_posix native_posix_64 nrf52_bsim efm32pg_stk3402a
     tags: libc
     ignore_faults: true
     testcases:
@@ -23,16 +23,18 @@ tests:
     - snprintf
   libraries.libc.sprintf_new:
     extra_args: CONF_FILE=prj_new.conf
-    platform_exclude: native_posix native_posix_64 nrf52_bsim
+    platform_exclude: native_posix native_posix_64 nrf52_bsim efm32pg_stk3402a
     tags: libc
     testcases:
     - EOF
   libraries.libc.picolibc.sprintf:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_picolibc.conf
     tags: libc picolibc
     ignore_faults: true
     filter: CONFIG_PICOLIBC_SUPPORTED
   libraries.libc.picolibc.sprintf_new:
+    platform_exclude: efm32pg_stk3402a
     extra_args: CONF_FILE=prj_picolibc_new.conf
     tags: libc picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED

--- a/tests/lib/spsc_pbuf/testcase.yaml
+++ b/tests/lib/spsc_pbuf/testcase.yaml
@@ -3,14 +3,14 @@ tests:
     integration_platforms:
       - native_posix
     # Exclude platform which does not link with cache functions
-    platform_exclude: ast1030_evb
+    platform_exclude: ast1030_evb efm32pg_stk3402a
     timeout: 120
 
   libraries.spsc_pbuf_cache:
     integration_platforms:
       - native_posix
     # Exclude platform which does not link with cache functions
-    platform_exclude: ast1030_evb
+    platform_exclude: ast1030_evb efm32pg_stk3402a
     timeout: 120
     extra_configs:
       - CONFIG_SPSC_PBUF_CACHE_ALWAYS=y
@@ -19,7 +19,7 @@ tests:
     integration_platforms:
       - native_posix
     # Exclude platform which does not link with cache functions
-    platform_exclude: ast1030_evb
+    platform_exclude: ast1030_evb efm32pg_stk3402a
     timeout: 120
     extra_configs:
       - CONFIG_SPSC_PBUF_CACHE_NEVER=y
@@ -28,7 +28,7 @@ tests:
     integration_platforms:
       - native_posix
     # Exclude platform which does not link with cache functions
-    platform_exclude: ast1030_evb
+    platform_exclude: ast1030_evb efm32pg_stk3402a
     timeout: 120
     extra_configs:
       - CONFIG_SPSC_PBUF_UTILIZATION=y

--- a/tests/lib/sys_util/testcase.yaml
+++ b/tests/lib/sys_util/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.sys_util:
+    platform_exclude: efm32pg_stk3402a
     tags: sys_util

--- a/tests/lib/time/testcase.yaml
+++ b/tests/lib/time/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   libraries.libc.time:
+    platform_exclude: efm32pg_stk3402a
     tags: libc
     filter: not CONFIG_ARCH_POSIX or CONFIG_NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
     timeout: 180

--- a/tests/misc/iterable_sections/testcase.yaml
+++ b/tests/misc/iterable_sections/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   misc.iterable_sections:
+    platform_exclude: efm32pg_stk3402a
     tags: iterable_sections
     arch_exclude: xtensa

--- a/tests/misc/print_format/testcase.yaml
+++ b/tests/misc/print_format/testcase.yaml
@@ -31,13 +31,16 @@ common:
 
 tests:
   printk.format:
+    platform_exclude: efm32pg_stk3402a
     tags: clib
   printk.format_newlib:
+    platform_exclude: efm32pg_stk3402a
     tags: clib newlib
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
     - CONFIG_NEWLIB_LIBC=y
   printk.format.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: clib picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -9,11 +9,11 @@ common:
 
 tests:
   portability.posix.common:
-    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb efm32pg_stk3402a
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   portability.posix.common.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb lpcxpresso55s06
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb lpcxpresso55s06 efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
@@ -22,14 +22,14 @@ tests:
     extra_configs:
       - CONFIG_ARCMWDT_LIBC=y
   portability.posix.common.tls:
-    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
       - CONFIG_MAIN_STACK_SIZE=1152
   portability.posix.common.tls.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb lpcxpresso55s06
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb lpcxpresso55s06 efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
@@ -48,6 +48,7 @@ tests:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_TEST_HW_STACK_PROTECTION=n
   portability.posix.common.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -3,13 +3,16 @@ common:
   tags: posix eventfd
 tests:
   portability.posix.eventfd:
+    platform_exclude: efm32pg_stk3402a
     min_ram: 32
   portability.posix.eventfd.newlib:
+    platform_exclude: efm32pg_stk3402a
     min_ram: 32
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   portability.posix.eventfd.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:

--- a/tests/posix/eventfd_basic/testcase.yaml
+++ b/tests/posix/eventfd_basic/testcase.yaml
@@ -4,27 +4,33 @@ common:
   min_ram: 32
 tests:
   portability.posix.eventfd_basic:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_POSIX_API=n
   portability.posix.eventfd_basic.posix_api:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_POSIX_API=y
   portability.posix.eventfd_basic.newlib:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_POSIX_API=n
   portability.posix.eventfd_basic.newlib.posix_api:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_POSIX_API=y
   portability.posix.eventfd_basic.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
   portability.posix.eventfd_basic.picolibc.posix_api:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -6,29 +6,35 @@ common:
     - fatfs
 tests:
   portability.posix.fs:
+    platform_exclude: efm32pg_stk3402a
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   portability.posix.fs.newlib:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   portability.posix.fs.tls:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
   portability.posix.fs.tls.newlib:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
   portability.posix.fs.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
   portability.posix.fs.tls.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -3,15 +3,18 @@ common:
   tags: posix getopt
 tests:
   portability.posix.getopt:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - qemu_x86
     min_flash: 64
     min_ram: 32
   portability.posix.getopt.newlib:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
   portability.posix.getopt.picolibc:
+    platform_exclude: efm32pg_stk3402a
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -4,7 +4,7 @@ tests:
     ignore_faults: true
     ignore_qemu_crash: true
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
-    platform_exclude: acrn_ehl_crb
+    platform_exclude: acrn_ehl_crb efm32pg_stk3402a
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -20,4 +20,4 @@ tests:
   coredump.backends.other:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_backend_other.conf
-    platform_exclude: acrn_ehl_crb
+    platform_exclude: acrn_ehl_crb efm32pg_stk3402a

--- a/tests/subsys/dsp/basicmath/testcase.yaml
+++ b/tests/subsys/dsp/basicmath/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   zdsp.basicmath:
+    platform_exclude: efm32pg_stk3402a
     filter: TOOLCHAIN_HAS_NEWLIB == 1 or CONFIG_ARCH_POSIX
     integration_platforms:
       - frdm_k64f
@@ -10,6 +11,7 @@ tests:
     min_flash: 128
     min_ram: 64
   zdsp.basicmath.fpu:
+    platform_exclude: efm32pg_stk3402a
     filter: (CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote

--- a/tests/subsys/input/api/testcase.yaml
+++ b/tests/subsys/input/api/testcase.yaml
@@ -2,6 +2,7 @@
 
 tests:
   input.api.thread:
+    platform_exclude: efm32pg_stk3402a
     tags: input
     integration_platforms:
       - native_posix
@@ -9,6 +10,7 @@ tests:
       - CONFIG_INPUT_MODE_THREAD=y
       - CONFIG_INPUT_THREAD_STACK_SIZE=1024
   input.api.synchronous:
+    platform_exclude: efm32pg_stk3402a
     tags: input
     integration_platforms:
       - native_posix

--- a/tests/subsys/jwt/testcase.yaml
+++ b/tests/subsys/jwt/testcase.yaml
@@ -2,6 +2,7 @@ common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
 tests:
   libraries.encoding.jwt:
+    platform_exclude: efm32pg_stk3402a
     min_ram: 96
     min_flash: 72
     timeout: 120

--- a/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
@@ -10,14 +10,14 @@ tests:
     extra_args: >
       OVERLAY_CONFIG="configuration/crc32.conf"
     platform_exclude: nucleo_h745zi_q_m4 arduino_portenta_h7_m4
-      stm32h747i_disco_m4 arduino_giga_r1_m4 esp32_net
+      stm32h747i_disco_m4 arduino_giga_r1_m4 esp32_net efm32pg_stk3402a
   mgmt.mcumgr.fs.mgmt.hash.supported.sha256:
     extra_args: >
       OVERLAY_CONFIG="configuration/sha256.conf"
     platform_exclude: nucleo_h745zi_q_m4 arduino_portenta_h7_m4
-      stm32h747i_disco_m4 arduino_giga_r1_m4 esp32_net
+      stm32h747i_disco_m4 arduino_giga_r1_m4 esp32_net efm32pg_stk3402a
   mgmt.mcumgr.fs.mgmt.hash.supported.all:
     extra_args: >
       OVERLAY_CONFIG="configuration/all.conf"
     platform_exclude: nucleo_h745zi_q_m4 arduino_portenta_h7_m4
-      stm32h747i_disco_m4 arduino_giga_r1_m4 esp32_net
+      stm32h747i_disco_m4 arduino_giga_r1_m4 esp32_net efm32pg_stk3402a

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_echo/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_echo/testcase.yaml
@@ -6,5 +6,6 @@
 tests:
   mgmt.mcumgr.os.echo:
     # FIXME: Exclude architectures that lack a reboot handler function
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: arm64 nios2 sparc arc xtensa mips
     tags: os_mgmt_echo mcumgr mgmt

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/testcase.yaml
@@ -12,6 +12,7 @@ tests:
   os.mgmt.info_no_hooks:
     # FIXME: Exclude architectures that lack a reboot handler function
     # FIXME: Exclude systems whereby the processor type is not known and emits a warning
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: arm64 nios2 sparc arc xtensa mips posix
     tags: os_mgmt_info
     extra_configs:
@@ -42,6 +43,7 @@ tests:
   os.mgmt.info_build_date:
     # FIXME: Exclude architectures that lack a reboot handler function
     # FIXME: Exclude systems whereby the processor type is not known and emits a warning
+    platform_exclude: efm32pg_stk3402a
     arch_exclude: arm64 nios2 sparc arc xtensa mips posix
     tags: os_mgmt_info
     extra_configs:

--- a/tests/subsys/pm/device_runtime_api/testcase.yaml
+++ b/tests/subsys/pm/device_runtime_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   pm.device_runtime.api:
+    platform_exclude: efm32pg_stk3402a
     tags: pm

--- a/tests/subsys/portability/cmsis_rtos_v1/testcase.yaml
+++ b/tests/subsys/portability/cmsis_rtos_v1/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   portability.cmsis_rtos_v1:
+    platform_exclude: efm32pg_stk3402a
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/tests/subsys/portability/cmsis_rtos_v2/testcase.yaml
+++ b/tests/subsys/portability/cmsis_rtos_v2/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   portability.cmsis_rtos_v2:
-    platform_exclude: m2gl025_miv intel_adsp_cavs15
+    platform_exclude: m2gl025_miv intel_adsp_cavs15 efm32pg_stk3402a
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -13,11 +13,13 @@ tests:
     extra_configs:
       - CONFIG_RTIO_SUBMIT_SEM=y
   rtio.api.userspace:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
     tags: rtio userspace
   rtio.api.userspace.submit_sem:
+    platform_exclude: efm32pg_stk3402a
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y

--- a/tests/subsys/settings/nvs/testcase.yaml
+++ b/tests/subsys/settings/nvs/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   system.settings.nvs:
+    platform_exclude: efm32pg_stk3402a
     depends_on: nvs
     min_ram: 32
     tags: settings_nvs

--- a/tests/subsys/shell/shell/testcase.yaml
+++ b/tests/subsys/shell/shell/testcase.yaml
@@ -6,6 +6,7 @@ common:
 
 tests:
   shell.core:
+    platform_exclude: efm32pg_stk3402a
     min_flash: 64
 
   shell.min:

--- a/tests/subsys/shell/shell_history/testcase.yaml
+++ b/tests/subsys/shell/shell_history/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   shell.history:
+    platform_exclude: efm32pg_stk3402a
     integration_platforms:
       - native_posix
     min_flash: 64

--- a/tests/subsys/zbus/dyn_channel/testcase.yaml
+++ b/tests/subsys/zbus/dyn_channel/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   message_bus.zbus.dyn_channel.static_and_dynamic_channels:
-    platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
+    platform_exclude: fvp_base_revc_2xaemv8a_smp_ns efm32pg_stk3402a
     tags: zbus

--- a/tests/subsys/zbus/integration/testcase.yaml
+++ b/tests/subsys/zbus/integration/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   message_bus.zbus.module_interaction_no_error:
     platform_exclude: qemu_cortex_a9 hifive_unleashed fvp_base_revc_2xaemv8a_smp_ns
+      efm32pg_stk3402a
     tags: zbus

--- a/tests/subsys/zbus/runtime_observers_registration/testcase.yaml
+++ b/tests/subsys/zbus/runtime_observers_registration/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   message_bus.zbus.runtime_obs_reg.add_and_remove_observers:
+    platform_exclude: efm32pg_stk3402a
     tags: zbus

--- a/tests/subsys/zbus/user_data/testcase.yaml
+++ b/tests/subsys/zbus/user_data/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   message_bus.zbus.user_data.channel_user_data:
-    platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
+    platform_exclude: fvp_base_revc_2xaemv8a_smp_ns efm32pg_stk3402a
     tags: zbus


### PR DESCRIPTION
Tests were done on Zephyr upstream, so additions left enabled. Some intermittant test failures have also been left enabled.