### PR TITLE
net: ipv6: Fix Kconfig dependencies when native IPv6 is disabled

### DIFF
--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -37,6 +37,8 @@ config NET_IF_IPV6_PREFIX_COUNT
 	int "Max number of IPv6 prefixes per network interface"
 	default 2
 
+if NET_NATIVE_IPV6
+
 config NET_INITIAL_HOP_LIMIT
 	int "Initial hop limit for a connection"
 	default 64
@@ -190,4 +192,5 @@ module-str = Log level for IPv6 neighbor cache
 module-help = Enables IPv6 Neighbor Cache code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
+endif # NET_NATIVE_IPV6
 endif # NET_IPV6


### PR DESCRIPTION
In case native IPv6 is disabled, Kconfig entries related to native IPv6 stack should not be enabled. Otherwise, circular dependencies can be created if native stack is disabled, as in case of recent changes in NET_IPV6_RA_RDNSS option (where a dependency for a native stack module was enabled).