### PR TITLE
driver: sensor: fix tmp108 build

### DIFF
--- a/drivers/sensor/tmp108/tmp108.c
+++ b/drivers/sensor/tmp108/tmp108.c
@@ -418,8 +418,9 @@ static int tmp108_pm_action(const struct device *dev,
 
 	return ret;
 }
-#endif
+#endif /* CONFIG_PM_DEVICE */
 
+#ifdef CONFIG_PM_DEVICE
 #define TMP108_DEFINE(inst, t)						   \
 	static struct tmp108_data tmp108_prv_data_##inst##t;		   \
 	static const struct tmp108_config tmp108_config_##inst##t = {	   \
@@ -437,6 +438,24 @@ static int tmp108_pm_action(const struct device *dev,
 			      POST_KERNEL,				   \
 			      CONFIG_SENSOR_INIT_PRIORITY,		   \
 			      &tmp108_driver_api);
+#else
+#define TMP108_DEFINE(inst, t)						   \
+	static struct tmp108_data tmp108_prv_data_##inst##t;		   \
+	static const struct tmp108_config tmp108_config_##inst##t = {	   \
+		.i2c_spec = I2C_DT_SPEC_INST_GET(inst),			   \
+		.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(inst,		   \
+						       alert_gpios, { 0 }),\
+		.reg_def = t##_CONF					   \
+	};								   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				   \
+			      &tmp108_init,				   \
+			      NULL,		   \
+			      &tmp108_prv_data_##inst##t,		   \
+			      &tmp108_config_##inst##t,			   \
+			      POST_KERNEL,				   \
+			      CONFIG_SENSOR_INIT_PRIORITY,		   \
+			      &tmp108_driver_api);
+#endif /* CONFIG_PM_DEVICE */
 
 #define TMP108_INIT(n) TMP108_DEFINE(n, TI_TMP108)
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Fixed tmp108 build when device_pm is not enabled