### PR TITLE
drivers: modem: fix includes for modem sms

### DIFF
--- a/drivers/modem/modem_sms.h
+++ b/drivers/modem/modem_sms.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_DRIVERS_MODEM_MODEM_SMS_H_
 #define ZEPHYR_DRIVERS_MODEM_MODEM_SMS_H_
 
+#include <zephyr/drivers/modem/sms.h>
+
 /**
  * @brief Notify all registered callbacks of a received SMS message
  *


### PR DESCRIPTION
Fixed modem sms header to include necessary headers.