### PR TITLE
drivers: sensor: Fix logging build of SX9328

### DIFF
--- a/drivers/sensor/sx9328/sx9328.c
+++ b/drivers/sensor/sx9328/sx9328.c
@@ -19,7 +19,7 @@
 
 #include "sx9328.h"
 
-LOG_MODULE_REGISTER(SX9398, CONFIG_SENSOR_LOG_LEVEL);
+LOG_MODULE_REGISTER(SX9328, CONFIG_SENSOR_LOG_LEVEL);
 
 /**
  * Set attributes for the device.

--- a/drivers/sensor/sx9328/sx9328_trigger.c
+++ b/drivers/sensor/sx9328/sx9328_trigger.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT semtech_sx9328
-
 #include <errno.h>
 
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Fixed issues preventing the SX9328 driver from building when logging is enabled.