### PR TITLE
drivers: sensor: Explicitly deassert reset on GNSS

### DIFF
--- a/drivers/sensor/cxd5605/cxd5605.h
+++ b/drivers/sensor/cxd5605/cxd5605.h
@@ -13,6 +13,6 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
 
-int setup_interrupts(const struct device *dev);
+int cxd5605_setup_interrupts(const struct device *dev);
 
 #endif /*  ZEPHYR_DRIVERS_SENSOR_CXD5605_CXD5605_H_ */


### PR DESCRIPTION
Fixed GNSS driver to function without board explicitly de-asserting the reset line.