### PR TITLE
boards: arm: Enable DPD flag on flash chip

### DIFF
--- a/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
+++ b/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
@@ -161,6 +161,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <6400000>;
+		has-dpd;
 		// note size is in bits
 		size = <0x04000000>;
 		jedec-id = [ef 60 17];


### PR DESCRIPTION
Enable using the DPD mode on our SPI NOR chip.