### PR TITLE
github: workflows: Turn nightly merge back on

### DIFF
--- a/.github/workflows/tmo-nightly-merge-main-tmo-main.yml
+++ b/.github/workflows/tmo-nightly-merge-main-tmo-main.yml
@@ -1,0 +1,26 @@
+name: Tmo Nightly Merge Main TmoMain
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "15 4 * * *"
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{secrets.MERGE_KEY}}
+      - run: |
+          git config user.name nightly-merge
+          git config user.email nightly-merge@github.com
+          git config merge.ours.driver true
+          echo "Current head hash for reverting if needed"
+          git rev-parse HEAD
+          git fetch
+          git checkout main
+          git checkout tmo-main
+          git merge -X theirs --no-edit --allow-unrelated-histories main
+          git push


### PR DESCRIPTION
Reather than reverting, this will preserve the record of when this was turned off and on.