### PR TITLE
boards: tmo_dev_edge: dts chosen watchdog to alias

### DIFF
--- a/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
+++ b/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
@@ -21,8 +21,6 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,sflash = &w25q64;
-		watchdog0 = &wdog0;
-		watchdog1 = &wdog1;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -46,6 +44,8 @@
 		red-pwm-led = &red_pwm_led;
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
+		watchdog0 = &wdog0;
+		watchdog1 = &wdog1;
 	};
 
 	leds {


### PR DESCRIPTION
fix building test samples by moving watchdog nodes from chosen to alias