### PR TITLE
subsys: shell: shell_ops.c  take from upstream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -242,5 +242,4 @@ subsys/net/lib/ping/ping.c merge=ours
 subsys/shell/modules/date_service.c merge=ours
 subsys/shell/shell_help.c merge=ours
 subsys/shell/shell_cmds.c merge=ours
-subsys/shell/shell_ops.c merge=ours
 west.yml merge=ours


### PR DESCRIPTION
unable to reproduce issue with long commands in history scrolling

.gitattributes: remove shell_ops.c